### PR TITLE
Fix amountbox

### DIFF
--- a/src/components/AmountEditable.tsx
+++ b/src/components/AmountEditable.tsx
@@ -161,7 +161,6 @@ export const AmountEditable: ParentComponent<{
     const isFiatMode = mode() === "fiat";
     const inputSanitizer = isFiatMode ? fiatInputSanitizer : satsInputSanitizer;
     const localValue = isFiatMode ? localFiat : localSats;
-    const inputRef = isFiatMode ? fiatInputRef : satsInputRef;
 
     let sane;
 
@@ -184,7 +183,7 @@ export const AmountEditable: ParentComponent<{
     }
 
     // After a button press make sure we re-focus the input
-    inputRef.focus();
+    focus();
   }
 
   function setFixedAmount(amount: string) {
@@ -220,16 +219,23 @@ export const AmountEditable: ParentComponent<{
 
   function toggle() {
     setMode((m) => (m === "sats" ? "fiat" : "sats"));
-    if (mode() === "sats") {
-      satsInputRef.focus();
-    } else {
-      fiatInputRef.focus();
-    }
+    focus();
   }
 
   onMount(() => {
-    satsInputRef.focus();
+    focus();
   });
+
+  function focus() {
+    // Make sure we actually have the inputs mounted before we try to focus them
+    if (isOpen() && satsInputRef && fiatInputRef) {
+      if (mode() === "sats") {
+        satsInputRef.focus();
+      } else {
+        fiatInputRef.focus();
+      }
+    }
+  }
 
   return (
     <Dialog.Root open={isOpen()}>
@@ -297,12 +303,9 @@ export const AmountEditable: ParentComponent<{
                 <For each={mode() === "fiat" ? FIXED_AMOUNTS_USD : FIXED_AMOUNTS_SATS}>
                   {(amount) => (
                     <button
-                      onClick={() => { setFixedAmount(amount.amount)
-                        if (mode() === "fiat") {
-                          fiatInputRef.focus();
-                        } else {
-                          satsInputRef.focus();
-                        }
+                      onClick={() => {
+                        setFixedAmount(amount.amount);
+                        focus();
                       }}
                       class="py-2 px-4 rounded-lg bg-white/10"
                     >

--- a/src/components/layout/Radio.tsx
+++ b/src/components/layout/Radio.tsx
@@ -1,7 +1,7 @@
 import { RadioGroup } from "@kobalte/core";
 import { For, Show } from "solid-js";
 
-type Choices = { value: string, label: string, caption: string }[]
+type Choices = { value: string; label: string; caption: string; disabled?: boolean }[];
 
 // TODO: how could would it be if we could just pass the estimated fees in here?
 export function StyledRadioGroup(props: { value: string, choices: Choices, onValueChange: (value: string) => void, small?: boolean, accent?: "red" | "white" }) {
@@ -24,8 +24,10 @@ export function StyledRadioGroup(props: { value: string, choices: Choices, onVal
               class={`ui-checked:bg-neutral-950 bg-white/10 rounded outline outline-black/50 ui-checked:outline-m-blue ui-checked:outline-2`}
               classList={{
                 "ui-checked:outline-m-red": props.accent === "red",
-                "ui-checked:outline-white": props.accent === "white"
+                "ui-checked:outline-white": props.accent === "white",
+                "ui-disabled:opacity-50": choice.disabled
               }}
+              disabled={choice.disabled}
             >
               <div class={props.small ? "py-2 px-2" : "py-3 px-4"}>
                 <RadioGroup.ItemInput />


### PR DESCRIPTION
this should fix the errors when scanning unified qrs / receive with no input... basically I was trying to focus the text input of the amount input even when the modal wasn't open, so it would throw an error

also caught a bug while doing this where the fee estimator for onchain was throwing errors that I wasn't catching, now added an error box possibly related to #195 stuff @benalleng


