### PR TITLE
catch paste errors

### DIFF
--- a/src/routes/Scanner.tsx
+++ b/src/routes/Scanner.tsx
@@ -74,10 +74,13 @@ export default function Scanner() {
         history.back();
     }
 
-    function handlePaste() {
-        navigator.clipboard.readText().then((text) => {
+    async function handlePaste() {
+        try {
+            const text = await navigator.clipboard.readText();
             setScanResult(text);
-        });
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     onMount(async () => {

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -358,19 +358,17 @@ export default function Send() {
         parsePaste(text);
     }
 
-    function handlePaste() {
+    async function handlePaste() {
         if (!navigator.clipboard.readText)
             return showToast(new Error("Clipboard not supported"));
 
-        navigator.clipboard
-            .readText()
-            .then((text) => {
-                setFieldDestination(text);
-                parsePaste(text);
-            })
-            .catch((e) => {
-                showToast(new Error("Failed to read clipboard: " + e.message));
-            });
+        try {
+            const text = await navigator.clipboard.readText();
+            setFieldDestination(text);
+            parsePaste(text);
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     async function processContacts(

--- a/src/utils/useCopy.ts
+++ b/src/utils/useCopy.ts
@@ -10,7 +10,7 @@ export const useCopy = ({ copiedTimeout = 2000 }: UseCopyProps = {}): [
     copied: Accessor<boolean>
 ] => {
     const [copied, setCopied] = createSignal(false);
-    let timeout: NodeJS.Timeout;
+    let timeout: number;
     const copy: CopyFn = async (text) => {
         await navigator.clipboard.writeText(text);
         setCopied(true);


### PR DESCRIPTION
I believe this should fix #250 

ios is weird where it doesn't allow you to use your own UI for paste, it wants to open up a "native" thingy that the user has to click

before, if the user clicked the mutiny paste button, allowed paste, and then clicked the mutiny paste button again you get the noisy error. now we catch that error instead of showing it. the ui is pretty obvious after a few taps that you really gotta hit the "native" paste tip