### PR TITLE
Enhances onClose() functionality of <AmountEditable />

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@kobalte/core':
     specifier: ^0.9.6

--- a/src/components/AmountCard.tsx
+++ b/src/components/AmountCard.tsx
@@ -73,6 +73,7 @@ export function AmountCard(props: {
     isAmountEditable?: boolean;
     setAmountSats?: (amount: bigint) => void;
     skipWarnings?: boolean;
+    exitRoute?: string;
     maxAmountSats?: bigint;
 }) {
     // Normally we want to add the fee to the amount, but for max amount we just show the max
@@ -111,6 +112,7 @@ export function AmountCard(props: {
                                                 : noop
                                         }
                                         skipWarnings={props.skipWarnings}
+                                        exitRoute={props.exitRoute}
                                         maxAmountSats={props.maxAmountSats}
                                         fee={props.fee}
                                     />
@@ -176,6 +178,7 @@ export function AmountCard(props: {
                                                 : noop
                                         }
                                         skipWarnings={props.skipWarnings}
+                                        exitRoute={props.exitRoute}
                                         maxAmountSats={props.maxAmountSats}
                                         fee={props.fee}
                                     />

--- a/src/components/AmountEditable.tsx
+++ b/src/components/AmountEditable.tsx
@@ -247,6 +247,20 @@ export const AmountEditable: ParentComponent<{
         }
     }
 
+    function handleClose() {
+        props.setAmountSats(BigInt(props.initialAmountSats));
+        setIsOpen(false);
+        setLocalSats(props.initialAmountSats);
+        setLocalFiat(
+            satsToUsd(
+                state.price,
+                parseInt(props.initialAmountSats || "0") || 0,
+                false
+            )
+        );
+        props.exitRoute && navigate(props.exitRoute);
+    }
+
     // What we're all here for in the first place: returning a value
     function handleSubmit(e: SubmitEvent | MouseEvent) {
         e.preventDefault();
@@ -328,44 +342,12 @@ export const AmountEditable: ParentComponent<{
                 <div class={DIALOG_POSITIONER}>
                     <Dialog.Content
                         class={DIALOG_CONTENT}
-                        onEscapeKeyDown={() => {
-                            props.setAmountSats(
-                                BigInt(props.initialAmountSats)
-                            );
-                            setIsOpen(false);
-                            setLocalSats(props.initialAmountSats);
-                            setLocalFiat(
-                                satsToUsd(
-                                    state.price,
-                                    parseInt(props.initialAmountSats || "0") ||
-                                        0,
-                                    false
-                                )
-                            );
-                            props.exitRoute && navigate(props.exitRoute);
-                        }}
+                        onEscapeKeyDown={handleClose}
                     >
                         {/* TODO: figure out how to submit on enter */}
                         <div class="w-full flex justify-end">
                             <button
-                                onClick={() => {
-                                    props.setAmountSats(
-                                        BigInt(props.initialAmountSats)
-                                    );
-                                    setIsOpen(false);
-                                    setLocalSats(props.initialAmountSats);
-                                    setLocalFiat(
-                                        satsToUsd(
-                                            state.price,
-                                            parseInt(
-                                                props.initialAmountSats || "0"
-                                            ) || 0,
-                                            false
-                                        )
-                                    );
-                                    props.exitRoute &&
-                                        navigate(props.exitRoute);
-                                }}
+                                onClick={handleClose}
                                 class="hover:bg-white/10 rounded-lg active:bg-m-blue w-8 h-8"
                             >
                                 <img src={close} alt="Close" />

--- a/src/components/AmountEditable.tsx
+++ b/src/components/AmountEditable.tsx
@@ -17,6 +17,7 @@ import { DIALOG_CONTENT, DIALOG_POSITIONER } from "~/styles/dialogs";
 import { InfoBox } from "./InfoBox";
 import { Network } from "~/logic/mutinyWalletSetup";
 import { FeesModal } from "./MoreInfoModal";
+import { useNavigate } from "@solidjs/router";
 
 const CHARACTERS = [
     "1",
@@ -138,9 +139,11 @@ export const AmountEditable: ParentComponent<{
     initialOpen: boolean;
     setAmountSats: (s: bigint) => void;
     skipWarnings?: boolean;
+    exitRoute?: string;
     maxAmountSats?: bigint;
     fee?: string;
 }> = (props) => {
+    const navigate = useNavigate();
     const [isOpen, setIsOpen] = createSignal(props.initialOpen);
     const [state, _actions] = useMegaStore();
     const [mode, setMode] = createSignal<"fiat" | "sats">("sats");
@@ -325,12 +328,44 @@ export const AmountEditable: ParentComponent<{
                 <div class={DIALOG_POSITIONER}>
                     <Dialog.Content
                         class={DIALOG_CONTENT}
-                        onEscapeKeyDown={() => setIsOpen(false)}
+                        onEscapeKeyDown={() => {
+                            props.setAmountSats(
+                                BigInt(props.initialAmountSats)
+                            );
+                            setIsOpen(false);
+                            setLocalSats(props.initialAmountSats);
+                            setLocalFiat(
+                                satsToUsd(
+                                    state.price,
+                                    parseInt(props.initialAmountSats || "0") ||
+                                        0,
+                                    false
+                                )
+                            );
+                            props.exitRoute && navigate(props.exitRoute);
+                        }}
                     >
                         {/* TODO: figure out how to submit on enter */}
                         <div class="w-full flex justify-end">
                             <button
-                                onClick={() => setIsOpen(false)}
+                                onClick={() => {
+                                    props.setAmountSats(
+                                        BigInt(props.initialAmountSats)
+                                    );
+                                    setIsOpen(false);
+                                    setLocalSats(props.initialAmountSats);
+                                    setLocalFiat(
+                                        satsToUsd(
+                                            state.price,
+                                            parseInt(
+                                                props.initialAmountSats || "0"
+                                            ) || 0,
+                                            false
+                                        )
+                                    );
+                                    props.exitRoute &&
+                                        navigate(props.exitRoute);
+                                }}
                                 class="hover:bg-white/10 rounded-lg active:bg-m-blue w-8 h-8"
                             >
                                 <img src={close} alt="Close" />

--- a/src/components/BetaWarningModal.tsx
+++ b/src/components/BetaWarningModal.tsx
@@ -42,7 +42,7 @@ export const WarningModal: ParentComponent<{
 }> = (props) => {
     const [open, setOpen] = createSignal(
         localStorage.getItem("betaWarned") !== "true" &&
-        getExistingSettings().network === "bitcoin"
+            getExistingSettings().network === "bitcoin"
     );
 
     function close() {

--- a/src/logic/browserCompatibility.ts
+++ b/src/logic/browserCompatibility.ts
@@ -11,7 +11,12 @@ export async function checkBrowserCompatibility(): Promise<boolean> {
 
     // Check if the browser supports WebAssembly
     console.debug("Checking WebAssembly");
-    if (typeof WebAssembly !== 'object' || !WebAssembly.validate(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00))) {
+    if (
+        typeof WebAssembly !== "object" ||
+        !WebAssembly.validate(
+            Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)
+        )
+    ) {
         throw new Error("WebAssembly is not supported.");
     }
 

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -323,6 +323,7 @@ export default function Receive() {
                                     amountSats={amount() || "0"}
                                     setAmountSats={setAmount}
                                     isAmountEditable
+                                    exitRoute={amount() ? "/receive" : "/"}
                                 />
 
                                 <Card title="Private tags">


### PR DESCRIPTION
Closes #205, closes #260

the functionalitty for the send route remains where it keeps you on the send page without sending you forward

additionally the input is reset back to the initialAmountSats when onClose() so there is not a secret error where the UI would show a different amoun than the input