### PR TITLE
Fix wasm check

### DIFF
--- a/src/logic/browserCompatibility.ts
+++ b/src/logic/browserCompatibility.ts
@@ -11,22 +11,7 @@ export async function checkBrowserCompatibility(): Promise<boolean> {
 
     // Check if the browser supports WebAssembly
     console.debug("Checking WebAssembly");
-    try {
-        if (
-            typeof WebAssembly === "object" &&
-            typeof WebAssembly.instantiate === "function"
-        ) {
-            const module = new WebAssembly.Module(
-                Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)
-            );
-            if (module instanceof WebAssembly.Module) {
-                // continue
-            } else {
-                throw new Error("WebAssembly is not supported.");
-            }
-        }
-    } catch (e) {
-        console.error(e);
+    if (typeof WebAssembly !== 'object' || !WebAssembly.validate(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00))) {
         throw new Error("WebAssembly is not supported.");
     }
 


### PR DESCRIPTION
Fixes https://github.com/MutinyWallet/mutiny-web/issues/246

Reproduce via `google-chrome --js-flags="--jitless"`

---

In your original code:

```
    try {
        if (
            typeof WebAssembly === "object" &&
            typeof WebAssembly.instantiate === "function"
        ) {
            const module = new WebAssembly.Module(
                Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)
            );
            if (module instanceof WebAssembly.Module) {
                // continue
            } else {
                throw new Error("WebAssembly is not supported.");
            }
        }
    } catch (e) {
        console.error(e);
        throw new Error("WebAssembly is not supported.");
    }
```

You are first checking if WebAssembly is an object and if it has a method called instantiate. If either of these checks fails, it should not enter the if block and go straight to the catch block, where it would throw an error "WebAssembly is not supported".

However, if for some reason it still enters the if block (e.g., due to an unexpected JavaScript behavior or a browser bug), it will try to call new WebAssembly.Module, which can throw a ReferenceError if WebAssembly is not defined, because you're trying to access a property of an undefined object. This ReferenceError is then caught by the catch block, and it's this error that you're seeing.

In the revised code:

```
console.debug("Checking WebAssembly");
if (typeof WebAssembly === 'object' && WebAssembly.validate(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00))) {
    // WebAssembly is supported
} else {
    throw new Error("WebAssembly is not supported.");
}
```

You are only checking if WebAssembly is an object and if it can validate a basic WebAssembly binary. The validate function is simpler to use than new WebAssembly.Module and it doesn't throw a ReferenceError if WebAssembly is not defined. If either of these checks fails, it will throw an error "WebAssembly is not supported", which should be caught by your checkBrowserCompat function.

This code should behave more predictably and avoid uncaught ReferenceErrors. It still properly checks for WebAssembly support and throws an error if it's not supported, but it does so in a safer way that avoids accessing properties or methods of undefined objects.