### PR TITLE
Swap fixes

### DIFF
--- a/src/components/BalanceBox.tsx
+++ b/src/components/BalanceBox.tsx
@@ -60,7 +60,7 @@ export default function BalanceBox(props: { loading?: boolean }) {
                 <Show when={!props.loading} fallback={<LoadingShimmer />}>
                     <div class="flex justify-between">
                         <Amount amountSats={totalOnchain()} showFiat />
-                        <Show when={!emptyBalance()}>
+                        <Show when={totalOnchain() != 0n }>
                             <div class="self-end justify-self-end">
                                 <A href="/swap" class={STYLE}>
                                     <img

--- a/src/routes/Swap.tsx
+++ b/src/routes/Swap.tsx
@@ -153,9 +153,8 @@ export default function Swap() {
                 }
             } catch (e) {
                 setChannelOpenResult({ failure_reason: eify(e) });
-                // showToast(eify(e))
             } finally {
-		setDone(true);
+                setDone(true);
                 setLoading(false);
             }
         }
@@ -228,11 +227,16 @@ export default function Swap() {
         }
 
         // If max we want to use the sweep fee estimator
-        if (amountSats() === maxOnchain()) {
-            return state.mutiny_wallet?.estimate_sweep_channel_open_fee();
+        if (amountSats() >= 0n && amountSats() === maxOnchain()) {
+            try {
+                return state.mutiny_wallet?.estimate_sweep_channel_open_fee();
+            } catch (e) {
+                console.error(e);
+                return undefined;
+            }
         }
 
-        if (amountSats()) {
+        if (amountSats() >= 0n) {
             try {
                 return state.mutiny_wallet?.estimate_tx_fee(
                     CHANNEL_FEE_ESTIMATE_ADDRESS,
@@ -241,7 +245,6 @@ export default function Swap() {
                 );
             } catch (e) {
                 console.error(e);
-                // showToast(eify(new Error("Unsufficient funds")))
                 return undefined;
             }
         }

--- a/src/routes/Swap.tsx
+++ b/src/routes/Swap.tsx
@@ -56,6 +56,7 @@ export default function Swap() {
     const [isConnecting, setIsConnecting] = createSignal(false);
 
     const [loading, setLoading] = createSignal(false);
+    const [done, setDone] = createSignal(false);
 
     const [selectedPeer, setSelectedPeer] = createSignal<string>("");
 
@@ -123,6 +124,7 @@ export default function Swap() {
         if (canSwap()) {
             try {
                 setLoading(true);
+                setDone(false);
                 const nodes = await state.mutiny_wallet?.list_nodes();
                 const firstNode = (nodes[0] as string) || "";
 
@@ -153,6 +155,7 @@ export default function Swap() {
                 setChannelOpenResult({ failure_reason: eify(e) });
                 // showToast(eify(e))
             } finally {
+		setDone(true);
                 setLoading(false);
             }
         }
@@ -220,7 +223,7 @@ export default function Swap() {
 
     const feeEstimate = createMemo(() => {
         // Balance can go down during swap so...
-        if (loading() || !!channelOpenResult()) {
+        if (loading() || !!channelOpenResult() || done()) {
             return undefined;
         }
 

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -224,6 +224,10 @@ export const Provider: ParentComponent = (props) => {
         }
     };
 
+    onCleanup(() => {
+        console.warn('Parent Component is being unmounted!!!');
+    });
+
     // Fetch status from remote on load
     onMount(() => {
         // eslint-disable-next-line


### PR DESCRIPTION
ChatGPT: Suspense and asynchronous operations: You are using Suspense and FullscreenLoader to handle asynchronous operations. If an asynchronous operation is ongoing when you navigate away, and then it completes and changes the state after you have navigated, this could potentially cause a re-render.

---

There was a time race that kept calling the fee estimator like 3-4 times in the span of navigating back to home. For some reason, doing it so fast causes it to call many times. Waiting on the success screen for a few seconds and then hitting nice will cause it to have a "not enough funds error" in the log. Then when clicking on the swap button causes a "dangit" error because not enough funds for the operation. 

This hopefully fixes all the weird transitions around swaps but there's an overall problem of nothing protecting the parent component from being remounted and another mutiny node manager from being instantiated again which is absolutely dangerous. 