### PR TITLE
Multi instance defense

### DIFF
--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -1,13 +1,5 @@
 import { NiceP } from "./layout";
-import {
-    For,
-    Match,
-    Show,
-    Switch,
-    createEffect,
-    createSignal,
-    onMount
-} from "solid-js";
+import { For, Match, Show, Switch, createEffect, createSignal } from "solid-js";
 import { useMegaStore } from "~/state/megaStore";
 import { ActivityItem as MutinyActivity } from "@mutinywallet/mutiny-wasm";
 import { ActivityItem, HackActivityType } from "./ActivityItem";

--- a/src/components/AmountEditable.tsx
+++ b/src/components/AmountEditable.tsx
@@ -162,14 +162,19 @@ export const AmountEditable: ParentComponent<{
     let fiatInputRef!: HTMLInputElement;
 
     const [inboundCapacity] = createResource(async () => {
-        const channels = await state.mutiny_wallet?.list_channels();
-        let inbound = 0;
+        try {
+            const channels = await state.mutiny_wallet?.list_channels();
+            let inbound = 0;
 
-        for (const channel of channels) {
-            inbound += channel.size - (channel.balance + channel.reserve);
+            for (const channel of channels) {
+                inbound += channel.size - (channel.balance + channel.reserve);
+            }
+
+            return inbound;
+        } catch (e) {
+            console.error(e);
+            return 0;
         }
-
-        return inbound;
     });
 
     const warningText = () => {

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -353,33 +353,44 @@ export function DetailsIdModal(props: {
 
     // TODO: is there a cleaner way to do refetch when id changes?
     const [data, { refetch }] = createResource(async () => {
-        if (kind() === "Lightning") {
-            console.debug("reading invoice: ", id());
-            const invoice = await state.mutiny_wallet?.get_invoice_by_hash(
-                id()
-            );
-            return invoice;
-        } else if (kind() === "ChannelClose") {
-            console.debug("reading channel close: ", id());
-            const closeItem = await state.mutiny_wallet?.get_channel_closure(
-                id()
-            );
+        try {
+            if (kind() === "Lightning") {
+                console.debug("reading invoice: ", id());
+                const invoice = await state.mutiny_wallet?.get_invoice_by_hash(
+                    id()
+                );
+                return invoice;
+            } else if (kind() === "ChannelClose") {
+                console.debug("reading channel close: ", id());
+                const closeItem =
+                    await state.mutiny_wallet?.get_channel_closure(id());
 
-            return closeItem;
-        } else {
-            console.debug("reading tx: ", id());
-            const tx = await state.mutiny_wallet?.get_transaction(id());
+                return closeItem;
+            } else {
+                console.debug("reading tx: ", id());
+                const tx = await state.mutiny_wallet?.get_transaction(id());
 
-            return tx;
+                return tx;
+            }
+        } catch (e) {
+            console.error(e);
+            return undefined;
         }
     });
 
     const tags = createMemo(() => {
         if (data() && data().labels && data().labels.length > 0) {
-            const contact = state.mutiny_wallet?.get_contact(data().labels[0]);
-            if (contact) {
-                return [tagToMutinyTag(contact)];
-            } else {
+            try {
+                const contact = state.mutiny_wallet?.get_contact(
+                    data().labels[0]
+                );
+                if (contact) {
+                    return [tagToMutinyTag(contact)];
+                } else {
+                    return [];
+                }
+            } catch (e) {
+                console.error(e);
                 return [];
             }
         } else {

--- a/src/components/LiquidityMonitor.tsx
+++ b/src/components/LiquidityMonitor.tsx
@@ -36,17 +36,22 @@ export function LiquidityMonitor() {
     const [state, _actions] = useMegaStore();
 
     const [channelInfo] = createResource(async () => {
-        const channels = await state.mutiny_wallet?.list_channels();
-        let inbound = 0n;
+        try {
+            const channels = await state.mutiny_wallet?.list_channels();
+            let inbound = 0n;
 
-        for (const channel of channels) {
-            inbound =
-                inbound +
-                BigInt(channel.size) -
-                BigInt(channel.balance + channel.reserve);
+            for (const channel of channels) {
+                inbound =
+                    inbound +
+                    BigInt(channel.size) -
+                    BigInt(channel.balance + channel.reserve);
+            }
+
+            return { inbound, channelCount: channels?.length };
+        } catch (e) {
+            console.error(e);
+            return { inbound: 0, channelCount: 0 };
         }
-
-        return { inbound, channelCount: channels?.length };
     });
 
     return (

--- a/src/components/Logs.tsx
+++ b/src/components/Logs.tsx
@@ -6,8 +6,16 @@ export function Logs() {
     const [state, _] = useMegaStore();
 
     async function handleSave() {
-        const logs = await state.mutiny_wallet?.get_logs();
-        downloadTextFile(logs.join("") || "", "mutiny-logs.txt", "text/plain");
+        try {
+            const logs = await state.mutiny_wallet?.get_logs();
+            downloadTextFile(
+                logs.join("") || "",
+                "mutiny-logs.txt",
+                "text/plain"
+            );
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     return (

--- a/src/components/Restart.tsx
+++ b/src/components/Restart.tsx
@@ -7,12 +7,16 @@ export function Restart() {
     const [hasStopped, setHasStopped] = createSignal(false);
 
     async function toggle() {
-        if (hasStopped()) {
-            await state.mutiny_wallet?.start();
-            setHasStopped(false);
-        } else {
-            await state.mutiny_wallet?.stop();
-            setHasStopped(true);
+        try {
+            if (hasStopped()) {
+                await state.mutiny_wallet?.start();
+                setHasStopped(false);
+            } else {
+                await state.mutiny_wallet?.stop();
+                setHasStopped(true);
+            }
+        } catch (e) {
+            console.error(e);
         }
     }
 

--- a/src/routes/Activity.tsx
+++ b/src/routes/Activity.tsx
@@ -26,23 +26,32 @@ import { LoadingShimmer } from "~/components/BalanceBox";
 function ContactRow() {
     const [state, _actions] = useMegaStore();
     const [contacts, { refetch }] = createResource(async () => {
-        const contacts = state.mutiny_wallet?.get_contacts();
+        try {
+            const contacts = state.mutiny_wallet?.get_contacts();
 
-        // FIXME: this is just types shenanigans I believe
-        const c: Contact[] = [];
-        if (contacts) {
-            for (const contact in contacts) {
-                c.push(contacts[contact]);
+            // FIXME: this is just types shenanigans I believe
+            const c: Contact[] = [];
+            if (contacts) {
+                for (const contact in contacts) {
+                    c.push(contacts[contact]);
+                }
             }
+            return c || [];
+        } catch (e) {
+            console.error(e);
+            return [];
         }
-        return c || [];
     });
     const [gradients] = createResource(contacts, gradientsPerContact);
 
     async function createContact(contact: ContactFormValues) {
         // FIXME: npub not valid? other undefineds
         const c = new Contact(contact.name, undefined, undefined, undefined);
-        await state.mutiny_wallet?.create_new_contact(c);
+        try {
+            await state.mutiny_wallet?.create_new_contact(c);
+        } catch (e) {
+            console.error(e);
+        }
         refetch();
     }
 

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -188,10 +188,14 @@ export default function Receive() {
                     undefined,
                     undefined
                 );
-                const newContactId =
-                    await state.mutiny_wallet?.create_new_contact(c);
-                if (newContactId) {
-                    return [newContactId];
+                try {
+                    const newContactId =
+                        await state.mutiny_wallet?.create_new_contact(c);
+                    if (newContactId) {
+                        return [newContactId];
+                    }
+                } catch (e) {
+                    console.error(e);
                 }
             }
 
@@ -221,7 +225,6 @@ export default function Receive() {
 
             return `bitcoin:${raw?.address}?${params}`;
         } catch (e) {
-            
             showToast(new Error("Failed to create invoice. Please try again."));
             console.error(e);
         }
@@ -245,27 +248,33 @@ export default function Receive() {
             const lightning = bip21.invoice;
             const address = bip21.address;
 
-            const invoice = await state.mutiny_wallet?.get_invoice(lightning);
+            try {
+                const invoice = await state.mutiny_wallet?.get_invoice(
+                    lightning
+                );
 
-            // If the invoice has a fees amount that's probably the LSP fee
-            if (invoice?.fees_paid) {
-                setLspFee(invoice.fees_paid);
-            }
+                // If the invoice has a fees amount that's probably the LSP fee
+                if (invoice?.fees_paid) {
+                    setLspFee(invoice.fees_paid);
+                }
 
-            if (invoice && invoice.paid) {
-                setReceiveState("paid");
-                setPaymentInvoice(invoice);
-                return "lightning_paid";
-            }
+                if (invoice && invoice.paid) {
+                    setReceiveState("paid");
+                    setPaymentInvoice(invoice);
+                    return "lightning_paid";
+                }
 
-            const tx = (await state.mutiny_wallet?.check_address(address)) as
-                | OnChainTx
-                | undefined;
+                const tx = (await state.mutiny_wallet?.check_address(
+                    address
+                )) as OnChainTx | undefined;
 
-            if (tx) {
-                setReceiveState("paid");
-                setPaymentTx(tx);
-                return "onchain_paid";
+                if (tx) {
+                    setReceiveState("paid");
+                    setPaymentTx(tx);
+                    return "onchain_paid";
+                }
+            } catch (e) {
+                console.error(e);
             }
         }
     }

--- a/src/routes/Scanner.tsx
+++ b/src/routes/Scanner.tsx
@@ -1,8 +1,8 @@
 import Reader from "~/components/Reader";
-import { createEffect, createSignal, onMount } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
 import { useNavigate } from "solid-start";
 import { Button } from "~/components/layout";
-import init, { PaymentParams } from "@mutinywallet/waila-wasm";
+import { PaymentParams } from "@mutinywallet/waila-wasm";
 import { showToast } from "~/components/Toaster";
 import { useMegaStore } from "~/state/megaStore";
 import { Result } from "~/utils/typescript";
@@ -82,10 +82,6 @@ export default function Scanner() {
             console.error(e);
         }
     }
-
-    onMount(async () => {
-        await init();
-    });
 
     // When we have a nice result we can head over to the send screen
     createEffect(() => {

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -408,10 +408,14 @@ export default function Send() {
                     undefined,
                     undefined
                 );
-                const newContactId =
-                    await state.mutiny_wallet?.create_new_contact(c);
-                if (newContactId) {
-                    return [newContactId];
+                try {
+                    const newContactId =
+                        await state.mutiny_wallet?.create_new_contact(c);
+                    if (newContactId) {
+                        return [newContactId];
+                    }
+                } catch (e) {
+                    console.error(e);
                 }
             }
 

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -208,7 +208,12 @@ export const Provider: ParentComponent = (props) => {
             setState({ dismissed_restore_prompt: true });
         },
         async listTags(): Promise<MutinyTagItem[]> {
-            return state.mutiny_wallet?.get_tag_items() as MutinyTagItem[];
+            try {
+                return state.mutiny_wallet?.get_tag_items() as MutinyTagItem[];
+            } catch (e) {
+                console.error(e);
+                return [];
+            }
         },
         setNwc(enabled: boolean) {
             localStorage.setItem("nwc_enabled", enabled.toString());

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -225,7 +225,16 @@ export const Provider: ParentComponent = (props) => {
     };
 
     onCleanup(() => {
-        console.warn('Parent Component is being unmounted!!!');
+        console.warn("Parent Component is being unmounted!!!");
+        state.mutiny_wallet
+            ?.stop()
+            .then(() => {
+                console.warn("Successfully stopped mutiny wallet");
+                sessionStorage.removeItem("MUTINY_WALLET_INITIALIZED");
+            })
+            .catch((e) => {
+                console.error("Error stopping mutiny wallet", e);
+            });
     });
 
     // Fetch status from remote on load


### PR DESCRIPTION
less noisy if you ignore the last commit, which is an attempt to catch all of these errors in the first place so none of this other defensive logic needs to be triggered

the actual very bad problem with the swap logic is that a potentially error-throwing function was being retriggered every time the state changed. the state changes when the balance goes down, which caused it to try and get the fee again.

IF this just resulted in them landing on the error page, then they'd be okay, because when they click "dangit" that reloads the page so they get a brand new `mutiny_wallet` instance and the old stuff is blown away

BUT because the error page unmounted the old mutiny_wallet without stopping it, AND then the swap logic auto-redirected to the home page, a new mutiny_wallet was getting initialized so now we had two mutiny_wallets.

enhancements in this pr:
1. stop mutiny on cleanup (when the parent component that holds all the state is unmounted, which should happen when we show the very bad error page)
2. if an existing session didn't clean up after itself, there's a sessionStorage var set so the page gets reloaded during setup (this makes setup take a bit longer, but should guard against having duplicate instances. this is less ideal than actually calling stop, but at this point in the object we don't have a reference to the mutiny_wallet object to stop it anymore)

a way to test this is to add a file called `Breaker.tsx` to the routes folder:

```tsx
import { createMemo, createSignal } from "solid-js";
import NavBar from "~/components/NavBar";
import {
    Button,
    DefaultMain,
    MutinyWalletGuard,
    SafeArea
} from "~/components/layout";
import { useMegaStore } from "~/state/megaStore";
import { useNavigate } from "solid-start";
import { BackLink } from "~/components/layout/BackLink";

const CHANNEL_FEE_ESTIMATE_ADDRESS =
    "bc1qf7546vg73ddsjznzq57z3e8jdn6gtw6au576j07kt6d9j7nz8mzsyn6lgf";

export default function Swap() {
    const [state, _actions] = useMegaStore();
    const navigate = useNavigate();

    createMemo;

    function breakMutiny() {
        setAmountSats(100000n);
        // comment this out if you want to stay on the error page
        navigate("/");
    }

    const [amountSats, setAmountSats] = createSignal(0n);

    const feeEstimate = createMemo(() => {
        if (amountSats() > 0n) {
            return state.mutiny_wallet?.estimate_tx_fee(
                CHANNEL_FEE_ESTIMATE_ADDRESS,
                amountSats(),
                undefined
            );
        }
        return undefined;
    });

    return (
        <MutinyWalletGuard>
            <SafeArea>
                <DefaultMain>
                    <pre>{feeEstimate()?.toString()}</pre>
                    <Button onClick={breakMutiny}>Break Mutiny</Button>
                    <BackLink />
                </DefaultMain>
                <NavBar activeTab="none" />
            </SafeArea>
        </MutinyWalletGuard>
    );
}

```

visit it at localhost:3420/breaker

(or you can go through the swap max logic again to retrigger manually)