### PR TITLE
add emergency kit and new error states

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mws",
-    "version": "0.3.11",
+    "version": "0.3.12",
     "license": "MIT",
     "packageManager": "pnpm@8.3.1",
     "scripts": {
@@ -38,7 +38,7 @@
         "@kobalte/core": "^0.9.6",
         "@kobalte/tailwindcss": "^0.5.0",
         "@modular-forms/solid": "^0.13.2",
-        "@mutinywallet/mutiny-wasm": "0.3.11",
+        "@mutinywallet/mutiny-wasm": "0.3.12",
         "@mutinywallet/waila-wasm": "^0.2.0",
         "@solid-primitives/upload": "^0.0.111",
         "@solidjs/meta": "^0.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^0.13.2
     version: 0.13.2(solid-js@1.7.5)
   '@mutinywallet/mutiny-wasm':
-    specifier: 0.3.11
-    version: 0.3.11
+    specifier: 0.3.12
+    version: 0.3.12
   '@mutinywallet/waila-wasm':
     specifier: ^0.2.0
     version: 0.2.0
@@ -1692,8 +1692,8 @@ packages:
       solid-js: 1.7.5
     dev: false
 
-  /@mutinywallet/mutiny-wasm@0.3.11:
-    resolution: {integrity: sha512-R4FzZbV848ndkUAsV01BixqMQi9pYzp7qMTxyOFLS9awh/8eEMC7xtIJ/Fkc0TTRPNXtyEfr9L2jGGLTSaveiQ==}
+  /@mutinywallet/mutiny-wasm@0.3.12:
+    resolution: {integrity: sha512-mlBFrG59RoAV4aF4e46Uq9UaIPSXd5LcFl+RMM05b5UUDKR4Etf5pQ9ynoKcJ3Aa/P/YS6CLTCwBhFBgOqb3AA==}
     dev: false
 
   /@mutinywallet/waila-wasm@0.2.0:

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -1,11 +1,13 @@
-import { Title } from "solid-start";
+import { A, Title } from "solid-start";
 import {
     Button,
     DefaultMain,
     LargeHeader,
+    NiceP,
     SafeArea,
     SmallHeader
 } from "~/components/layout";
+import { ExternalLink } from "./layout/ExternalLink";
 
 export default function ErrorDisplay(props: { error: Error }) {
     return (
@@ -18,6 +20,17 @@ export default function ErrorDisplay(props: { error: Error }) {
                     <span class="font-bold">{props.error.name}</span>:{" "}
                     {props.error.message}
                 </p>
+                <NiceP>
+                    Try reloading this page or clicking the "Dangit" button. If
+                    you keep having problems,{" "}
+                    <ExternalLink href="https://matrix.to/#/#mutiny-community:lightninghackers.com">
+                        reach out to us for support.
+                    </ExternalLink>
+                </NiceP>
+                <NiceP>
+                    Getting desperate? Try the{" "}
+                    <A href="/emergencykit">emergency kit.</A>
+                </NiceP>
                 <div class="h-full" />
                 <Button
                     onClick={() => (window.location.href = "/")}

--- a/src/components/Logs.tsx
+++ b/src/components/Logs.tsx
@@ -1,13 +1,12 @@
+import { MutinyWallet } from "@mutinywallet/mutiny-wasm";
 import { Button, InnerCard, NiceP, VStack } from "~/components/layout";
-import { useMegaStore } from "~/state/megaStore";
 import { downloadTextFile } from "~/utils/download";
 
 export function Logs() {
-    const [state, _] = useMegaStore();
-
     async function handleSave() {
         try {
-            const logs = await state.mutiny_wallet?.get_logs();
+            const logs = await MutinyWallet.get_logs();
+
             downloadTextFile(
                 logs.join("") || "",
                 "mutiny-logs.txt",

--- a/src/components/SetupErrorDisplay.tsx
+++ b/src/components/SetupErrorDisplay.tsx
@@ -1,7 +1,32 @@
 import { Title } from "solid-start";
-import { DefaultMain, LargeHeader, NiceP, SafeArea } from "~/components/layout";
+import {
+    DefaultMain,
+    LargeHeader,
+    NiceP,
+    SafeArea,
+    SmallHeader
+} from "~/components/layout";
 import { ExternalLink } from "./layout/ExternalLink";
 import { Match, Switch } from "solid-js";
+import { ImportExport } from "./ImportExport";
+import { Logs } from "./Logs";
+import { DeleteEverything } from "./DeleteEverything";
+
+function ErrorFooter() {
+    return (
+        <>
+            <div class="h-full" />
+            <p class="self-center text-neutral-500 mt-4">
+                Bugs? Feedback?{" "}
+                <span class="text-neutral-400">
+                    <ExternalLink href="https://github.com/MutinyWallet/mutiny-web/issues">
+                        Create an issue
+                    </ExternalLink>
+                </span>
+            </p>
+        </>
+    );
+}
 
 export default function SetupErrorDisplay(props: { error: Error }) {
     return (
@@ -22,18 +47,10 @@ export default function SetupErrorDisplay(props: { error: Error }) {
                             this page, or close this tab and refresh the other
                             one.
                         </NiceP>
-                        <div class="h-full" />
-                        <p class="self-center text-neutral-500 mt-4">
-                            Bugs? Feedback?{" "}
-                            <span class="text-neutral-400">
-                                <ExternalLink href="https://github.com/MutinyWallet/mutiny-web/issues">
-                                    Create an issue
-                                </ExternalLink>
-                            </span>
-                        </p>
+                        <ErrorFooter />
                     </DefaultMain>
                 </Match>
-                <Match when={true}>
+                <Match when={props.error.message.startsWith("Browser error")}>
                     <Title>Incompatible browser</Title>
                     <DefaultMain>
                         <LargeHeader>Incompatible browser detected</LargeHeader>
@@ -61,15 +78,39 @@ export default function SetupErrorDisplay(props: { error: Error }) {
                             Supported Browsers
                         </ExternalLink>
 
-                        <div class="h-full" />
-                        <p class="self-center text-neutral-500 mt-4">
-                            Bugs? Feedback?{" "}
-                            <span class="text-neutral-400">
-                                <ExternalLink href="https://github.com/MutinyWallet/mutiny-web/issues">
-                                    Create an issue
-                                </ExternalLink>
-                            </span>
+                        <ErrorFooter />
+                    </DefaultMain>
+                </Match>
+                <Match when={true}>
+                    <Title>Failed to load</Title>
+                    <DefaultMain>
+                        <LargeHeader>Failed to load Mutiny</LargeHeader>
+                        <p class="bg-white/10 rounded-xl p-4 font-mono">
+                            <span class="font-bold">{props.error.name}</span>:{" "}
+                            {props.error.message}
                         </p>
+                        <NiceP>
+                            Something went wrong while booting up Mutiny Wallet.
+                        </NiceP>
+                        <NiceP>
+                            If your wallet seems broken, here are some tools to
+                            try to debug and repair it.
+                        </NiceP>
+                        <NiceP>
+                            If you have any questions on what these buttons do,
+                            please{" "}
+                            <ExternalLink href="https://matrix.to/#/#mutiny-community:lightninghackers.com">
+                                reach out to us for support.
+                            </ExternalLink>
+                        </NiceP>
+                        <ImportExport emergency />
+                        <Logs />
+                        <div class="rounded-xl p-4 flex flex-col gap-2 bg-m-red">
+                            <SmallHeader>Danger zone</SmallHeader>
+                            <DeleteEverything emergency />
+                        </div>
+
+                        <ErrorFooter />
                     </DefaultMain>
                 </Match>
             </Switch>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,11 @@
-import { JSX, ParentComponent, Show, Suspense, createResource } from "solid-js";
+import {
+    JSX,
+    ParentComponent,
+    Show,
+    Suspense,
+    createResource,
+    createSignal
+} from "solid-js";
 import Linkify from "./Linkify";
 import { Button, ButtonLink } from "./Button";
 import { Checkbox as KCheckbox, Separator } from "@kobalte/core";
@@ -7,6 +14,7 @@ import check from "~/assets/icons/check.svg";
 import { MutinyTagItem } from "~/utils/tags";
 import { generateGradient } from "~/utils/gradientHash";
 import close from "~/assets/icons/close.svg";
+import { A } from "solid-start";
 
 export { Button, ButtonLink, Linkify };
 
@@ -84,9 +92,24 @@ export const DefaultMain: ParentComponent = (props) => {
 };
 
 export const FullscreenLoader = () => {
+    const [waitedTooLong, setWaitedTooLong] = createSignal(false);
+
+    setTimeout(() => {
+        setWaitedTooLong(true);
+    }, 10000);
+
     return (
-        <div class="w-full h-[100dvh] flex justify-center items-center">
+        <div class="w-full h-[100dvh] flex flex-col gap-4 justify-center items-center">
             <LoadingSpinner wide />
+            <Show when={waitedTooLong()}>
+                <p class="max-w-[20rem] text-neutral-400">
+                    Stuck on this screen? Try reloading. If that doesn't work,
+                    check out the{" "}
+                    <A class="text-white" href="/emergencykit">
+                        emergency kit.
+                    </A>
+                </p>
+            </Show>
         </div>
     );
 };

--- a/src/logic/browserCompatibility.ts
+++ b/src/logic/browserCompatibility.ts
@@ -6,7 +6,7 @@ export async function checkBrowserCompatibility(): Promise<boolean> {
         localStorage.removeItem("test");
     } catch (e) {
         console.error(e);
-        throw new Error("LocalStorage is not supported.");
+        throw new Error("Browser error: LocalStorage is not supported.");
     }
 
     // Check if the browser supports WebAssembly
@@ -17,7 +17,7 @@ export async function checkBrowserCompatibility(): Promise<boolean> {
             Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)
         )
     ) {
-        throw new Error("WebAssembly is not supported.");
+        throw new Error("Browser error: WebAssembly is not supported.");
     }
 
     console.debug("Checking indexedDB");
@@ -26,7 +26,7 @@ export async function checkBrowserCompatibility(): Promise<boolean> {
         await openDatabase();
     } catch (e) {
         console.error(e);
-        throw new Error("IndexedDB is not supported.");
+        throw new Error("Browser error: IndexedDB is not supported.");
     }
 
     return true;

--- a/src/logic/mutinyWalletSetup.ts
+++ b/src/logic/mutinyWalletSetup.ts
@@ -117,15 +117,18 @@ export async function setupMutinyWallet(
     console.log("Using esplora address", esplora);
     console.log("Using rgs address", rgs);
     console.log("Using lsp address", lsp);
-
     const mutinyWallet = await new MutinyWallet(
+        // Password
         "",
+        // Mnemonic
         undefined,
         proxy,
         network,
         esplora,
         rgs,
-        lsp
+        lsp,
+        // Do not connect peers
+        undefined
     );
 
     const nodes = await mutinyWallet.list_nodes();

--- a/src/routes/EmergencyKit.tsx
+++ b/src/routes/EmergencyKit.tsx
@@ -1,0 +1,45 @@
+import { DeleteEverything } from "~/components/DeleteEverything";
+import { ImportExport } from "~/components/ImportExport";
+import { Logs } from "~/components/Logs";
+import NavBar from "~/components/NavBar";
+import {
+    DefaultMain,
+    LargeHeader,
+    NiceP,
+    SafeArea,
+    SmallHeader,
+    VStack
+} from "~/components/layout";
+import { BackLink } from "~/components/layout/BackLink";
+import { ExternalLink } from "~/components/layout/ExternalLink";
+
+export default function EmergencyKit() {
+    return (
+        <SafeArea>
+            <DefaultMain>
+                <BackLink />
+                <LargeHeader>Emergency Kit</LargeHeader>
+                <VStack>
+                    <NiceP>
+                        If your wallet seems broken, here are some tools to try
+                        to debug and repair it.
+                    </NiceP>
+                    <NiceP>
+                        If you have any questions on what these buttons do,
+                        please{" "}
+                        <ExternalLink href="https://matrix.to/#/#mutiny-community:lightninghackers.com">
+                            reach out to us for support.
+                        </ExternalLink>
+                    </NiceP>
+                    <ImportExport emergency />
+                    <Logs />
+                    <div class="rounded-xl p-4 flex flex-col gap-2 bg-m-red overflow-x-hidden">
+                        <SmallHeader>Danger zone</SmallHeader>
+                        <DeleteEverything emergency />
+                    </div>
+                </VStack>
+            </DefaultMain>
+            <NavBar activeTab="none" />
+        </SafeArea>
+    );
+}

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -14,6 +14,8 @@ import { SeedWords } from "~/components/SeedWords";
 import { SettingsStringsEditor } from "~/components/SettingsStringsEditor";
 import { useMegaStore } from "~/state/megaStore";
 import { LiquidityMonitor } from "~/components/LiquidityMonitor";
+import { A } from "solid-start";
+import { Suspense } from "solid-js";
 
 export default function Settings() {
     const [store, _actions] = useMegaStore();
@@ -41,6 +43,13 @@ export default function Settings() {
                             </VStack>
                         </Card>
                         <SettingsStringsEditor />
+                        <Card title="Emergency Kit">
+                            <NiceP>
+                                Having some serious problems with your wallet?
+                                Check out the{" "}
+                                <A href="/emergencykit">emergency kit.</A>
+                            </NiceP>
+                        </Card>
                         <Card title="If you know what you're doing">
                             <VStack>
                                 <NiceP>

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -151,17 +151,23 @@ export const Provider: ParentComponent = (props) => {
                 });
             } catch (e) {
                 console.error(e);
+                setState({ setup_error: eify(e) });
             }
         },
         async deleteMutinyWallet(): Promise<void> {
-            await state.mutiny_wallet?.stop();
-            setState((prevState) => ({
-                ...prevState,
-                mutiny_wallet: undefined,
-                deleting: true
-            }));
-            MutinyWallet.import_json("{}");
-            localStorage.clear();
+            try {
+                if (state.mutiny_wallet) {
+                    await state.mutiny_wallet?.stop();
+                }
+                setState((prevState) => ({
+                    ...prevState,
+                    mutiny_wallet: undefined,
+                    deleting: true
+                }));
+                MutinyWallet.import_json("{}");
+            } catch (e) {
+                console.error(e);
+            }
         },
         setWaitlistId(waitlist_id: string) {
             setState({ waitlist_id });


### PR DESCRIPTION
relies on https://github.com/MutinyWallet/mutiny-node/pull/616

this covers a few bad error states.

1. if the node manager panics during setup, the error screen will include the "emergency kit" items of import / export, download logs, and delete everything, all of which will now work without a node manager present
2. on regular error screens (which shouldn't really happen anymore because we're catching all errors afaik) there's a link to a new `/emergencykit` route
3. in settings there's also a link to `/emergencykit`

basically, if someone is unable to load at all, they should be able to get to the emergency kit, and if they are able to load and navigate they can get to `/emergencykit` even if they don't have a url bar