### PR TITLE
hide encryption page

### DIFF
--- a/src/routes/settings/Backup.tsx
+++ b/src/routes/settings/Backup.tsx
@@ -60,7 +60,8 @@ export default function Backup() {
     function wroteDownTheWords() {
         setLoading(true);
         actions.setHasBackedUp();
-        navigate("/settings/encrypt");
+        // navigate("/settings/encrypt");
+        navigate("/");
         setLoading(false);
     }
 

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -92,14 +92,14 @@ export default function Settings() {
                                 text: "Restore",
                                 accent: "red"
                             },
-                            {
-                                href: "/settings/encrypt",
-                                text: "Change Password",
-                                disabled: !state.has_backed_up,
-                                caption: !state.has_backed_up
-                                    ? "Backup first to unlock encryption"
-                                    : undefined
-                            },
+                            // {
+                            //     href: "/settings/encrypt",
+                            //     text: "Change Password",
+                            //     disabled: !state.has_backed_up,
+                            //     caption: !state.has_backed_up
+                            //         ? "Backup first to unlock encryption"
+                            //         : undefined
+                            // },
                             {
                                 href: "/settings/servers",
                                 text: "Servers",


### PR DESCRIPTION
not removing encryption for existing encrypted users, just hiding the current CTAs