### PR TITLE
Close dialog on select receive flavor

### DIFF
--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -319,6 +319,11 @@ export default function Receive() {
         }
     }
 
+    function selectFlavor(flavor: string) {
+        setFlavor(flavor as ReceiveFlavor);
+        setMethodChooserOpen(false);
+    }
+
     const [paidState, { refetch }] = createResource(bip21Raw, checkIfPaid);
 
     const network = state.mutiny_wallet?.get_network() as Network;
@@ -418,7 +423,7 @@ export default function Receive() {
                                 >
                                     <StyledRadioGroup
                                         value={flavor()}
-                                        onValueChange={setFlavor}
+                                        onValueChange={selectFlavor}
                                         choices={RECEIVE_FLAVORS}
                                         accent="white"
                                         vertical


### PR DESCRIPTION
Will now close the dialog when you select an option from this screen instead of having the user need to click the X afterwards
![image](https://github.com/MutinyWallet/mutiny-web/assets/15256660/4ca0ffbb-4d38-413a-b7c5-54fc9431896e)
