### PR TITLE
Swap SuccessScreen now accurately displays amount

### DIFF
--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -200,7 +200,7 @@ export default {
         insufficient_funds: "You don't have enough funds to make this channel",
         header: "Swap to Lightning",
         initiated: "Swap Initiated",
-        sats_added: "sats will be added to your Lightning balance",
+        sats_added: "+{{amount}} sats will be added to your Lightning balance",
         use_existing: "Use existing peer",
         choose_peer: "Choose a peer",
         peer_connect_label: "Connect to new peer",

--- a/src/routes/Swap.tsx
+++ b/src/routes/Swap.tsx
@@ -300,16 +300,30 @@ export default function Swap() {
                                         {i18n.t("swap.initiated")}
                                     </h1>
                                     <p class="text-xl text-center">
-                                        +
-                                        {channelOpenResult()?.channel?.balance.toLocaleString() ??
-                                            "0"}{" "}
-                                        {i18n.t("swap.sats_added")}
+                                        {i18n.t("swap.sats_added", {
+                                            amount: (
+                                                Number(
+                                                    channelOpenResult()?.channel
+                                                        ?.balance
+                                                ) +
+                                                Number(
+                                                    channelOpenResult()?.channel
+                                                        ?.reserve
+                                                )
+                                            ).toLocaleString()
+                                        })}
                                     </p>
                                     <div class="text-sm text-center text-white/70">
                                         <AmountFiat
                                             amountSats={
-                                                channelOpenResult()?.channel
-                                                    ?.balance
+                                                Number(
+                                                    channelOpenResult()?.channel
+                                                        ?.balance
+                                                ) +
+                                                Number(
+                                                    channelOpenResult()?.channel
+                                                        ?.reserve
+                                                )
                                             }
                                         />
                                     </div>


### PR DESCRIPTION
Closes #400 

amount now calculated as balance + reserve

wanted to avoid just using `amountSats()` incase of an error that isn't caught it will display "+0" instead of showing an amount even though the swap didn't go through