### PR TITLE
don't store default settings

### DIFF
--- a/src/components/BetaWarningModal.tsx
+++ b/src/components/BetaWarningModal.tsx
@@ -3,8 +3,8 @@ import { ParentComponent, createSignal } from "solid-js";
 import { DIALOG_CONTENT, DIALOG_POSITIONER, OVERLAY } from "./DetailsModal";
 import { ModalCloseButton, SmallHeader } from "./layout";
 import { ExternalLink } from "./layout/ExternalLink";
-import { getExistingSettings } from "~/logic/mutinyWalletSetup";
 import { useI18n } from "~/i18n/context";
+import { useMegaStore } from "~/state/megaStore";
 
 export function BetaWarningModal() {
     const i18n = useI18n();
@@ -34,9 +34,11 @@ export const WarningModal: ParentComponent<{
     linkText: string;
     title: string;
 }> = (props) => {
+    const [state, _actions] = useMegaStore();
+
     const [open, setOpen] = createSignal(
         localStorage.getItem("betaWarned") !== "true" &&
-            getExistingSettings().network === "bitcoin"
+            state.settings?.network === "bitcoin"
     );
 
     function close() {

--- a/src/components/DecryptDialog.tsx
+++ b/src/components/DecryptDialog.tsx
@@ -19,7 +19,7 @@ export function DecryptDialog() {
         e.preventDefault();
         setLoading(true);
         try {
-            await actions.setupMutinyWallet(undefined, password());
+            await actions.setup(password());
 
             // If we get this far and the state stills wants a password that means the password was wrong
             if (state.needs_password) {

--- a/src/routes/Swap.tsx
+++ b/src/routes/Swap.tsx
@@ -75,10 +75,7 @@ export default function Swap() {
     }
 
     const hasLsp = () => {
-        return (
-            !!localStorage.getItem("MUTINY_SETTINGS_lsp") ||
-            !!import.meta.env.VITE_LSP
-        );
+        return !!state.settings?.lsp;
     };
 
     const getPeers = async () => {

--- a/src/routes/settings/Servers.tsx
+++ b/src/routes/settings/Servers.tsx
@@ -2,8 +2,7 @@ import { createForm, url } from "@modular-forms/solid";
 import { TextField } from "~/components/layout/TextField";
 import {
     MutinyWalletSettingStrings,
-    getExistingSettings,
-    setAndGetMutinySettings
+    setSettings
 } from "~/logic/mutinyWalletSetup";
 import {
     Button,
@@ -20,19 +19,19 @@ import { ExternalLink } from "~/components/layout/ExternalLink";
 import { BackLink } from "~/components/layout/BackLink";
 import NavBar from "~/components/NavBar";
 import { useI18n } from "~/i18n/context";
+import { useMegaStore } from "~/state/megaStore";
 
 export function SettingsStringsEditor() {
     const i18n = useI18n();
-    const existingSettings = getExistingSettings();
+    const [state, _actions] = useMegaStore();
     const [settingsForm, { Form, Field }] =
         createForm<MutinyWalletSettingStrings>({
-            initialValues: existingSettings
+            initialValues: state.settings
         });
 
     async function handleSubmit(values: MutinyWalletSettingStrings) {
         try {
-            const newSettings = { ...existingSettings, ...values };
-            await setAndGetMutinySettings(newSettings);
+            await setSettings(values);
             window.location.reload();
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
the old behavior was to aggressively add all environment variables to the user's localstorage. we would do this on every setup, which, for instance, overwrote a setting if the user deleted a string (like the lsp)

now we only add stuff to a new USER_ prefixed storage key when the user sets a setting to be different than the default value

this makes it possible for us to change default values for users who haven't set custom values

also I refactored a bit and the whole settings stuff is a lot more straightforward now