### PR TITLE
get rid of delay for existing tab checking

### DIFF
--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -257,41 +257,32 @@ export const Provider: ParentComponent = (props) => {
             });
     });
 
-    // Fetch status from remote on load
     onMount(() => {
-        function handleExisting() {
-            if (state.existing_tab_detected) {
-                setState({
-                    setup_error: new Error(
-                        "Existing tab detected, aborting setup"
-                    )
-                });
-            } else {
-                console.log("running setup node manager...");
-
-                actions
-                    .setup()
-                    .then(() => console.log("node manager setup done"));
-
-                // Setup an event listener to stop the mutiny wallet when the page unloads
-                window.onunload = async (_e) => {
-                    console.log("stopping mutiny_wallet");
-                    await state.mutiny_wallet?.stop();
-                    console.log("mutiny_wallet stopped");
-                    sessionStorage.removeItem("MUTINY_WALLET_INITIALIZED");
-                };
-            }
-        }
-
-        function handleGoodBrowser() {
-            console.log("checking if any other tabs are open");
-            // 500ms should hopefully be enough time for any tabs to reply
-            timeout(500).then(handleExisting);
-        }
-
         if (!state.mutiny_wallet && !state.deleting) {
             console.log("checking for browser compatibility...");
-            actions.checkBrowserCompat().then(handleGoodBrowser);
+            actions.checkBrowserCompat().then(() => {
+                if (state.existing_tab_detected) {
+                    setState({
+                        setup_error: new Error(
+                            "Existing tab detected, aborting setup"
+                        )
+                    });
+                } else {
+                    console.log("running setup node manager...");
+
+                    actions
+                        .setup()
+                        .then(() => console.log("node manager setup done"));
+
+                    // Setup an event listener to stop the mutiny wallet when the page unloads
+                    window.onunload = async (_e) => {
+                        console.log("stopping mutiny_wallet");
+                        await state.mutiny_wallet?.stop();
+                        console.log("mutiny_wallet stopped");
+                        sessionStorage.removeItem("MUTINY_WALLET_INITIALIZED");
+                    };
+                }
+            });
         }
     });
 

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -4,7 +4,6 @@
 import {
     ParentComponent,
     createContext,
-    createEffect,
     onCleanup,
     onMount,
     useContext
@@ -21,7 +20,6 @@ import { MutinyBalance, MutinyWallet } from "@mutinywallet/mutiny-wasm";
 import { MutinyTagItem } from "~/utils/tags";
 import { checkBrowserCompatibility } from "~/logic/browserCompatibility";
 import eify from "~/utils/eify";
-import { timeout } from "~/utils/timeout";
 import { ParsedParams } from "~/logic/waila";
 import { subscriptionValid } from "~/utils/subscriptions";
 
@@ -61,7 +59,6 @@ export type MegaStore = [
         sync(): Promise<void>;
         setHasBackedUp(): void;
         listTags(): Promise<MutinyTagItem[]>;
-        checkBrowserCompat(): Promise<boolean>;
         checkForSubscription(justPaid?: boolean): Promise<void>;
     }
 ];
@@ -233,14 +230,6 @@ export const Provider: ParentComponent = (props) => {
                 console.error(e);
                 return [];
             }
-        },
-        async checkBrowserCompat(): Promise<boolean> {
-            try {
-                return await checkBrowserCompatibility();
-            } catch (e) {
-                setState({ setup_error: eify(e) });
-                return false;
-            }
         }
     };
 
@@ -257,46 +246,8 @@ export const Provider: ParentComponent = (props) => {
             });
     });
 
-    onMount(() => {
-        if (!state.mutiny_wallet && !state.deleting) {
-            console.log("checking for browser compatibility...");
-            actions.checkBrowserCompat().then(() => {
-                if (state.existing_tab_detected) {
-                    setState({
-                        setup_error: new Error(
-                            "Existing tab detected, aborting setup"
-                        )
-                    });
-                } else {
-                    console.log("running setup node manager...");
-
-                    actions
-                        .setup()
-                        .then(() => console.log("node manager setup done"));
-
-                    // Setup an event listener to stop the mutiny wallet when the page unloads
-                    window.onunload = async (_e) => {
-                        console.log("stopping mutiny_wallet");
-                        await state.mutiny_wallet?.stop();
-                        console.log("mutiny_wallet stopped");
-                        sessionStorage.removeItem("MUTINY_WALLET_INITIALIZED");
-                    };
-                }
-            });
-        }
-    });
-
-    createEffect(() => {
-        const interval = setInterval(async () => {
-            await actions.sync();
-        }, 3 * 1000); // Poll every 3 seconds
-
-        onCleanup(() => {
-            clearInterval(interval);
-        });
-    });
-
-    onMount(() => {
+    onMount(async () => {
+        // Set up existing tab detector
         const channel = new BroadcastChannel("tab-detector");
 
         // First we let everyone know we exist
@@ -306,7 +257,13 @@ export const Provider: ParentComponent = (props) => {
             // If any tabs reply, we know there's an existing tab so abort setup
             if (e.data.type === "EXISTING_TAB") {
                 console.debug("there's an existing tab");
-                setState({ existing_tab_detected: true });
+                setState({
+                    existing_tab_detected: true,
+                    setup_error: new Error(
+                        "Existing tab detected, aborting setup"
+                    )
+                });
+                return;
             }
 
             // If we get notified of a new tab, we let it know we exist
@@ -316,9 +273,41 @@ export const Provider: ParentComponent = (props) => {
             }
         };
 
-        onCleanup(() => {
-            channel.close();
-        });
+        console.log("checking for browser compatibility");
+        try {
+            await checkBrowserCompatibility();
+        } catch (e) {
+            setState({ setup_error: eify(e) });
+            return;
+        }
+
+        // Setup catches its own errors and sets state itself
+        console.log("running setup node manager");
+        if (
+            !state.mutiny_wallet &&
+            !state.deleting &&
+            !state.setup_error &&
+            !state.existing_tab_detected
+        ) {
+            await actions.setup();
+        } else {
+            console.warn("setup aborted");
+        }
+
+        console.log("node manager setup done");
+
+        // Setup an event listener to stop the mutiny wallet when the page unloads
+        window.onunload = async (_e) => {
+            console.log("stopping mutiny_wallet");
+            await state.mutiny_wallet?.stop();
+            console.log("mutiny_wallet stopped");
+            sessionStorage.removeItem("MUTINY_WALLET_INITIALIZED");
+        };
+
+        // Set up syncing
+        setInterval(async () => {
+            await actions.sync();
+        }, 3 * 1000); // Poll every 3 seconds
     });
 
     const store = [state, actions] as MegaStore;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,9 @@ export default defineConfig({
             "@kobalte/core",
             "@solid-primitives/upload",
             "i18next",
-            "i18next-browser-languagedetector"
+            "i18next-browser-languagedetector",
+            "@capacitor/clipboard",
+            "@capacitor/core"
         ],
         // This is necessary because otherwise `vite dev` can't find the wasm
         exclude: ["@mutinywallet/mutiny-wasm", "@mutinywallet/waila-wasm"]


### PR DESCRIPTION
when I set up existing tab checking I put in 500ms timer to give it extra buffer to catch tabs... 
~~now that we have extra instance detection from the cloud I'm removing the delay~~
apparently cloud detection doesn't help this case. other two points remain:

this 1. speeds up startup times, 2. doesn't seem to miss any existing tabs in my testing anyway so maybe the buffer never helped at all