### PR TITLE
Move types from global.d.ts to tsconfig.json

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite-plugin-pwa/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "jsxImportSource": "solid-js",
         "jsx": "preserve",
         "strict": true,
-        "types": ["solid-start/env", "node"],
+        "types": ["solid-start/env", "node", "vite-plugin-pwa/client"],
         "baseUrl": "./",
         "paths": {
             "~/*": ["./src/*"]


### PR DESCRIPTION
Hi,

 If that's okay I'd love to help ! I'll start with some low hanging fruit issues/fixes/optimizations that I see to get to know the codebase

Anyhow, the PR is for the `vite-pwa` types in the `global.d.ts` file. Since you already use the `compilerOptions.types` attribute in the `tsconfig` (and they basically do the same thing) I figured one less file at the root of the project would be better