### PR TITLE
Move postcss config to vite's config file

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,10 @@ import solid from "solid-start/vite";
 import { defineConfig } from "vite";
 import { VitePWA, VitePWAOptions } from "vite-plugin-pwa";
 import wasm from "vite-plugin-wasm";
+import autoprefixer from "autoprefixer";
+import tailwindcss from "tailwindcss";
 
-import * as path from 'path'
+import * as path from "path";
 
 const pwaOptions: Partial<VitePWAOptions> = {
     base: "/",
@@ -62,5 +64,10 @@ export default defineConfig({
         ],
         // This is necessary because otherwise `vite dev` can't find the wasm
         exclude: ["@mutinywallet/mutiny-wasm", "@mutinywallet/waila-wasm"]
+    },
+    css: {
+        postcss: {
+            plugins: [autoprefixer(), tailwindcss()]
+        }
     }
 });


### PR DESCRIPTION
Just another simple change, moving the config to `vite.config.ts` allows one less file and having types

They aren't used right now and the config will most likely not be needed after the integration of the lightning css engine but still