### PR TITLE
Fix tagToMutinyTag ts error

### DIFF
--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -25,8 +25,21 @@ export function tagsToIds(tags?: MutinyTagItem[]): string[] {
 }
 
 export function tagToMutinyTag(tag: TagItem): MutinyTagItem {
-    // @ts-expect-error: FIXME: make typescript less mad about this
-    return tag as MutinyTagItem;
+    let kind: MutinyTagItem["kind"];
+
+    switch (tag.kind) {
+        case 0: {
+            kind = "Label";
+            break;
+        }
+        case 1:
+        default: {
+            kind = "Contact";
+            break;
+        }
+    }
+
+    return { ...tag, kind };
 }
 
 export function sortByLastUsed(a: MutinyTagItem, b: MutinyTagItem) {


### PR DESCRIPTION
Fixed the TS error, not sure if you're fans or haters of `switch` though, of course will change to ifs if preferred.

But one weird thing is that the type of `kind` is supposed to be a number in the input and a string in the output. Either the input is badly typed or there might be some bugs in the app you use `kind` somewhere since the return type was lying to you until now

I'll edit this PR after I check which one it is 

EDIT: Kind of overwhelmed for now by the codebase, I'll need some time to figure how to pass through this function and print a `console.log` (to know what's in the original `tag.kind`)