### PR TITLE
Clear error after send button disabled and enhance error catches

### DIFF
--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -109,6 +109,8 @@ export default {
         },
         error_low_balance:
             "We do not have enough balance to pay the given amount.",
+        error_invoice_match:
+            "Amount requested, {{amount}} SATS, does not equal amount set.",
         error_clipboard: "Clipboard not supported",
         error_keysend: "Keysend failed",
         error_LNURL: "LNURL Pay failed"

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -259,14 +259,25 @@ export default function Send() {
         }
     };
 
-    const insufficientFunds = () => {
-        if (source() === "onchain") {
-            return maxOnchain() < amountSats();
+    const amountError = () => {
+        setError("");
+        if (source() === "onchain" && maxOnchain() < amountSats()) {
+            return setError(i18n.t("send.error_low_balance"));
         }
-        if (source() === "lightning") {
-            return (
-                (state.balance?.lightning ?? 0n) <= amountSats() &&
-                setError(i18n.t("send.error_low_balance"))
+        if (
+            source() === "lightning" &&
+            (state.balance?.lightning ?? 0n) <= amountSats()
+        ) {
+            return setError(i18n.t("send.error_low_balance"));
+        } else if (
+            source() === "lightning" &&
+            !!invoice()?.amount_sats &&
+            amountSats() !== invoice()?.amount_sats
+        ) {
+            return setError(
+                i18n.t("send.error_invoice_match", {
+                    amount: invoice()?.amount_sats?.toLocaleString()
+                })
             );
         }
     };
@@ -561,7 +572,7 @@ export default function Send() {
             !destination() ||
             sending() ||
             amountSats() === 0n ||
-            !!insufficientFunds() ||
+            !!amountError() ||
             !!error()
         );
     });


### PR DESCRIPTION
Closes #462 

Also included a very obscure catch wherby the send button is disabled if there is and amount in the invoice but it does not equal amountSats() `invoice().amount_sats !== amountSats()` unsure if/how this would ever occur as having the ability to edit the amount is only possible if there is no amount set in the invoice. If it seems unneccessary I'm happy to remove it

This video below is only possible because of some altered logic `isAmountEditable={true}`

[Kazam_screencast_00003.webm](https://github.com/MutinyWallet/mutiny-web/assets/108441023/ee8ce4c9-e24b-4e55-84c5-4fbff41bd5a0)
