### PR TITLE
Delete all for amountEditable should use PointerEvents

### DIFF
--- a/src/components/AmountEditable.tsx
+++ b/src/components/AmountEditable.tsx
@@ -92,9 +92,8 @@ function SingleDigitButton(props: {
         >
             <button
                 class="font-semi font-inter flex items-center justify-center rounded-lg p-2 text-4xl text-white active:bg-m-blue disabled:opacity-50 md:hover:bg-white/10"
-                onMouseDown={onHold}
-                onMouseUp={endHold}
-                onMouseLeave={endHold}
+                onPointerDown={onHold}
+                onPointerUp={endHold}
                 onClick={onClick}
             >
                 {props.character}


### PR DESCRIPTION
Fixes a bug where the hold "DEL" to delete all only worked on Desktop, `PointerEvents` should work on all devices. Additionally did not replace `onMouseLeave` with `onPointerLeave` as it isn't necessary in this logic