### PR TITLE
Filter for mutiny-wasm when unlinking

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ local:
     pnpm link --global "@mutinywallet/mutiny-wasm"
 
 remote:
-    pnpm unlink "@mutinywallet/mutiny-wasm" && pnpm install
+    pnpm unlink --filter "@mutinywallet/mutiny-wasm" && pnpm install
 
 test:
     pnpm exec playwright test


### PR DESCRIPTION
Closes #478 and resolves an error when running `pnpm build` after unlinking