### PR TITLE
change "lint" to pre-commit and add format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ just test-ui
 
 Hopefully your editor picks up on the `.prettirrc` file and auto formats accordingly. If you want to format everything in the project run `pnpm run format`.
 
+## Contributing
+
+Before committing make sure to run `pnpm run pre-commit`. This will typecheck, lint, and format everything so CI won't hassle you.
+
 ### Local
 
 If you want to develop against a local version of [the node manager](https://github.com/MutinyWallet/mutiny-node), you may want to `pnpm link` it.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "start": "solid-start start",
         "check-types": "tsc --noemit",
         "eslint": "eslint src",
-        "lint": "pnpm run eslint && pnpm run check-types",
+        "pre-commit": "pnpm run eslint && pnpm run check-types && pnpm run format",
         "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
         "check-format": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\""
     },


### PR DESCRIPTION
I rather not make this a pre-commit hook for everyone because I don't like that workflow (sometimes I need to do a wip commit that doesn't typecheck yet) but feel free to set it locally