### PR TITLE
Center X for nostr contact tags

### DIFF
--- a/src/styles/solid-select.css
+++ b/src/styles/solid-select.css
@@ -28,7 +28,7 @@
 
 .solid-select-multi-value-remove {
     /* TODO: there's gotta be a better way to vertically center this */
-    @apply -mt-2 pl-2 pr-1 text-2xl leading-3;
+    @apply -mt-[2px] pl-2 pr-1 text-2xl leading-3;
 }
 
 .solid-select-input {


### PR DESCRIPTION
I think this ultimately has to do with the fact that solid-select doesn't actually use an "x" but instead uses an "⨯" character so centering is rather difficult.

transitioning over to using a kobalte-core select like in the currency selector may be the move but for now, adjusting the negative margin centers the x

production:
![image](https://github.com/MutinyWallet/mutiny-web/assets/108441023/4edaee82-3f64-4a33-9696-e629a6d5f099)

PR:
![image](https://github.com/MutinyWallet/mutiny-web/assets/108441023/9de30cad-d509-4864-875e-56b9ca85a0ae)
