### PR TITLE
Currency change no longer requires reload

### DIFF
--- a/src/components/ChooseCurrency.tsx
+++ b/src/components/ChooseCurrency.tsx
@@ -1,5 +1,6 @@
 import { createForm } from "@modular-forms/solid";
 import { createSignal, Show } from "solid-js";
+import { useNavigate } from "solid-start";
 
 import {
     Button,
@@ -93,8 +94,9 @@ export const FIAT_OPTIONS: Currency[] = [
 export function ChooseCurrency() {
     const i18n = useI18n();
     const [error, setError] = createSignal<Error>();
-    const [state, _actions] = useMegaStore();
+    const [state, actions] = useMegaStore();
     const [loading, setLoading] = createSignal(false);
+    const navigate = useNavigate();
 
     function findCurrencyByValue(value: string) {
         return FIAT_OPTIONS.find((currency) => currency.value === value);
@@ -119,13 +121,12 @@ export function ChooseCurrency() {
     const handleFormSubmit = async (f: ChooseCurrencyForm) => {
         setLoading(true);
         try {
-            localStorage.setItem(
-                "fiat_currency",
-                JSON.stringify(findCurrencyByValue(f.fiatCurrency))
+            actions.saveFiat(
+                findCurrencyByValue(f.fiatCurrency) || FIAT_OPTIONS[1]
             );
 
             await timeout(1000);
-            window.location.href = "/";
+            navigate("/");
         } catch (e) {
             console.error(e);
             setError(eify(e));
@@ -152,9 +153,6 @@ export function ChooseCurrency() {
                                 options={FIAT_OPTIONS}
                                 label={i18n.t(
                                     "settings.currency.select_currency_label"
-                                )}
-                                caption={i18n.t(
-                                    "settings.currency.select_currency_caption"
                                 )}
                             />
                         )}

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -90,11 +90,6 @@ export default function Settings() {
                         header={i18n.t("settings.general")}
                         links={[
                             {
-                                href: "/settings/currency",
-                                text: i18n.t("settings.currency.title"),
-                                caption: i18n.t("settings.currency.caption")
-                            },
-                            {
                                 href: "/settings/channels",
                                 text: i18n.t("settings.channels.title")
                             },
@@ -115,6 +110,11 @@ export default function Settings() {
                                 caption: !state.has_backed_up
                                     ? "Backup first to unlock encryption"
                                     : undefined
+                            },
+                            {
+                                href: "/settings/currency",
+                                text: i18n.t("settings.currency.title"),
+                                caption: i18n.t("settings.currency.caption")
                             },
                             {
                                 href: "/settings/servers",


### PR DESCRIPTION
relies on https://github.com/MutinyWallet/mutiny-node/pull/758

works with the addition of mutiny-node#758 such that a new currency is fetched but switching back before the cache timeout keeps the currencies in cache so they can be swapped quickly without querying the coingecko api. The bitcoin currency option still never reaches out to the api.

Also makes the SmallSubtleAmount update when the price changes, this fixes a bug whereby the user could race the price api and set the sats amount before the fiat amount had a chance to be calculated. Production leaves the secondary amount at 0

[!](https://github.com/MutinyWallet/mutiny-web/assets/108441023/5723a9c4-06b3-47ac-bbd1-b52634e3430e)
