### PR TITLE
revert: amount loading logic

### DIFF
--- a/src/components/ActivityItem.tsx
+++ b/src/components/ActivityItem.tsx
@@ -17,7 +17,6 @@ export const ActivityAmount: ParentComponent<{
     positive?: boolean;
     center?: boolean;
 }> = (props) => {
-    const [state, _actions] = useMegaStore();
     return (
         <div
             class="flex flex-col gap-1"
@@ -39,7 +38,6 @@ export const ActivityAmount: ParentComponent<{
                 <AmountFiat
                     amountSats={Number(props.amount)}
                     denominationSize="sm"
-                    loading={state.price === 0}
                 />
             </div>
         </div>

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -15,7 +15,6 @@ function prettyPrintAmount(n?: number | bigint): string {
 
 export function AmountSats(props: {
     amountSats: bigint | number | undefined;
-    loading?: boolean;
     icon?: "lightning" | "chain" | "plus" | "minus";
     denominationSize?: "sm" | "lg" | "xl";
 }) {
@@ -35,7 +34,7 @@ export function AmountSats(props: {
                 <Show when={props.icon === "minus"}>
                     <span>-</span>
                 </Show>
-                {props.loading ? "…" : prettyPrintAmount(props.amountSats)}
+                {prettyPrintAmount(props.amountSats)}
                 &nbsp;
                 <span
                     class="text-base font-light"
@@ -69,7 +68,6 @@ export function AmountSats(props: {
 
 export function AmountFiat(props: {
     amountSats: bigint | number | undefined;
-    loading?: boolean;
     denominationSize?: "sm" | "lg" | "xl";
 }) {
     const [state, _] = useMegaStore();
@@ -84,7 +82,7 @@ export function AmountFiat(props: {
 
     return (
         <h2 class="font-light">
-            {props.loading ? "…" : amountInFiat()}
+            {amountInFiat()}
             <span
                 classList={{
                     "text-sm": props.denominationSize === "sm",
@@ -93,7 +91,7 @@ export function AmountFiat(props: {
                 }}
             >
                 &nbsp;
-                {props.loading ? "" : state.fiat.value}
+                {state.fiat.value}
             </span>
         </h2>
     );

--- a/src/components/BalanceBox.tsx
+++ b/src/components/BalanceBox.tsx
@@ -75,7 +75,6 @@ export function BalanceBox(props: { loading?: boolean }) {
                                             state.balance?.lightning || 0
                                         }
                                         denominationSize="sm"
-                                        loading={state.price === 0}
                                     />
                                 </div>
                             </div>
@@ -98,7 +97,6 @@ export function BalanceBox(props: { loading?: boolean }) {
                                 <AmountFiat
                                     amountSats={totalOnchain()}
                                     denominationSize="sm"
-                                    loading={state.price === 0}
                                 />
                             </div>
                         </div>

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -179,14 +179,28 @@ export const Provider: ParentComponent = (props) => {
                     }
                 }
 
-                // Get balance optimistically
+                // Get balance + price optimistically
                 const balance = await mutinyWallet.get_balance();
+                let price;
+                try {
+                    if (state.fiat.value === "BTC") {
+                        price = 1;
+                    } else {
+                        price = await mutinyWallet.get_bitcoin_price(
+                            state.fiat.value.toLowerCase() || "usd"
+                        );
+                    }
+                } catch (e) {
+                    console.error(e);
+                    price = 0;
+                }
 
                 setState({
                     mutiny_wallet: mutinyWallet,
                     wallet_loading: false,
                     subscription_timestamp: subscription_timestamp,
                     load_stage: "done",
+                    price: price || 0,
                     balance
                 });
             } catch (e) {


### PR DESCRIPTION
Reverts a change from #503 so that there is not an amount loading indicator.

In combination with https://github.com/MutinyWallet/mutiny-node/pull/764 node version we should be able to never see a load time for instant prices