### PR TITLE
Currency selector no longer resets to USD on no-selection

### DIFF
--- a/src/components/ChooseCurrency.tsx
+++ b/src/components/ChooseCurrency.tsx
@@ -121,9 +121,7 @@ export function ChooseCurrency() {
     const handleFormSubmit = async (f: ChooseCurrencyForm) => {
         setLoading(true);
         try {
-            actions.saveFiat(
-                findCurrencyByValue(f.fiatCurrency) || FIAT_OPTIONS[1]
-            );
+            actions.saveFiat(findCurrencyByValue(f.fiatCurrency) || state.fiat);
 
             await timeout(1000);
             navigate("/");


### PR DESCRIPTION
When pressing the select currency button without selecting an option, it would always reset to USD even if the displayed select option value was another currency

I was able to use state.fiat as the logic for setting the fiat will be done by the time the user gets to this page, no concern of undefined behavior