### PR TITLE
Display all send fieldDestination errors

### DIFF
--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -364,6 +364,9 @@ export default function Send() {
                             setLnurlp(source.lnurl);
                             setSource("lightning");
                         }
+                    })
+                    .catch((e) => {
+                        showToast(eify(e));
                     });
             } else {
                 setAmountSats(source.amount_sats || 0n);
@@ -690,11 +693,6 @@ export default function Send() {
                                         />
                                     </VStack>
                                 </Card>
-                                <Show when={error()}>
-                                    <InfoBox accent="red">
-                                        <p>{error()}</p>
-                                    </InfoBox>
-                                </Show>
                                 <AmountCard
                                     amountSats={amountSats().toString()}
                                     setAmountSats={setAmountSats}
@@ -702,6 +700,11 @@ export default function Send() {
                                     isAmountEditable={isAmtEditable()}
                                     maxAmountSats={maxAmountSats()}
                                 />
+                                <Show when={error()}>
+                                    <InfoBox accent="red">
+                                        <p>{error()}</p>
+                                    </InfoBox>
+                                </Show>
                             </Match>
                             <Match when={true}>
                                 <DestinationInput
@@ -712,7 +715,14 @@ export default function Send() {
                                 />
                             </Match>
                         </Switch>
-                        <Show when={destination()}>
+                        <Show
+                            when={
+                                address() ||
+                                invoice() ||
+                                nodePubkey() ||
+                                lnurlp()
+                            }
+                        >
                             <VStack>
                                 <Button
                                     disabled={sendButtonDisabled()}


### PR DESCRIPTION
Closes #594 
Should catch more destination parsing errors relating to things beyond the waila

(also moves some component child-parent organization so that buttons and errors aren't visible before they should be

Something to think about, should consider making a more "user" readable error vs human readable error here?

### TODO
- more testing to make sure I've caught them all