### PR TITLE
Use Capacitor for all vibrations

### DIFF
--- a/src/utils/vibrate.ts
+++ b/src/utils/vibrate.ts
@@ -1,19 +1,18 @@
-import { Capacitor } from "@capacitor/core";
 import { Haptics } from "@capacitor/haptics";
 import { NotificationType } from "@capacitor/haptics/dist/esm/definitions";
 
 export const vibrate = async (millis = 250) => {
-    if (Capacitor.isNativePlatform()) {
+    try {
         await Haptics.vibrate({ duration: millis });
-    } else {
-        window.navigator.vibrate(millis);
+    } catch (error) {
+        console.warn(error);
     }
 };
 
 export const vibrateSuccess = async () => {
-    if (Capacitor.isNativePlatform()) {
+    try {
         await Haptics.notification({ type: NotificationType.Success });
-    } else {
-        window.navigator.vibrate([35, 65, 21]);
+    } catch (error) {
+        console.warn(error);
     }
 };


### PR DESCRIPTION
when calling `window.navigator.vibrate` on browsers that didn't support it it would throw an error, so we just let Capacitor handle it for us