### PR TITLE
Add Brazilian Real BRL currency

### DIFF
--- a/src/components/ChooseCurrency.tsx
+++ b/src/components/ChooseCurrency.tsx
@@ -71,6 +71,12 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Brazilian Real BRL",
+        value: "BRL",
+        hasSymbol: "R$",
+        maxFractionalDigits: 2
+    },
+    {
         label: "British Pound GBP",
         value: "GBP",
         hasSymbol: "₤",

--- a/src/components/ChooseCurrency.tsx
+++ b/src/components/ChooseCurrency.tsx
@@ -95,7 +95,7 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 0
     },
     { label: "Kuwaiti Dinar KWD", value: "KWD", maxFractionalDigits: 3 }
-];
+].sort((a, b) => (a.value > b.value ? 1 : b.value > a.value ? -1 : 0));
 
 export function ChooseCurrency() {
     const i18n = useI18n();

--- a/src/components/ChooseCurrency.tsx
+++ b/src/components/ChooseCurrency.tsx
@@ -43,7 +43,6 @@ type ChooseCurrencyForm = {
  *  }
  */
 
-//Bitcoin and USD need to be FIAT_OPTIONS[0] and FIAT_OPTIONS[1] respectively, they are called in megaStore.tsx
 export const FIAT_OPTIONS: Currency[] = [
     {
         label: "Bitcoin BTC",
@@ -96,6 +95,9 @@ export const FIAT_OPTIONS: Currency[] = [
     },
     { label: "Kuwaiti Dinar KWD", value: "KWD", maxFractionalDigits: 3 }
 ].sort((a, b) => (a.value > b.value ? 1 : b.value > a.value ? -1 : 0));
+
+export const USD_INDEX = FIAT_OPTIONS.findIndex((fo) => fo.value === "USD");
+export const BTC_INDEX = FIAT_OPTIONS.findIndex((fo) => fo.value === "BTC");
 
 export function ChooseCurrency() {
     const i18n = useI18n();

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -12,7 +12,12 @@ import {
 import { createStore } from "solid-js/store";
 import { useNavigate, useSearchParams } from "solid-start";
 
-import { Currency, FIAT_OPTIONS } from "~/components/ChooseCurrency";
+import {
+    BTC_INDEX,
+    Currency,
+    FIAT_OPTIONS,
+    USD_INDEX
+} from "~/components/ChooseCurrency";
 import { checkBrowserCompatibility } from "~/logic/browserCompatibility";
 import {
     doubleInitDefense,
@@ -90,7 +95,7 @@ export const Provider: ParentComponent = (props) => {
         price: 0,
         fiat: localStorage.getItem("fiat_currency")
             ? (JSON.parse(localStorage.getItem("fiat_currency")!) as Currency)
-            : FIAT_OPTIONS[1],
+            : FIAT_OPTIONS[USD_INDEX],
         has_backed_up: localStorage.getItem("has_backed_up") === "true",
         balance: undefined as MutinyBalance | undefined,
         last_sync: undefined as number | undefined,
@@ -264,7 +269,7 @@ export const Provider: ParentComponent = (props) => {
                             balance: newBalance,
                             last_sync: Date.now(),
                             price: 1,
-                            fiat: FIAT_OPTIONS[0]
+                            fiat: FIAT_OPTIONS[BTC_INDEX]
                         });
                     }
                 }


### PR DESCRIPTION
- Add **Brazilian Real BRL** currency.
- Order list of currencies alphabetically by `value`.