### PR TITLE
Make MegaStoreProvider higher in root components

### DIFF
--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -39,7 +39,9 @@ export function ErrorDisplay(props: { error: Error }) {
                 </NiceP>
                 <NiceP>
                     {i18n.t("error.general.getting_desperate")}{" "}
-                    <A href="/emergencykit">{i18n.t("error.emergency_link")}</A>
+                    <A href="/settings/emergencykit">
+                        {i18n.t("error.emergency_link")}
+                    </A>
                 </NiceP>
                 <div class="h-full" />
                 <Button

--- a/src/components/layout/Misc.tsx
+++ b/src/components/layout/Misc.tsx
@@ -152,7 +152,7 @@ export const FullscreenLoader = () => {
             <Show when={waitedTooLong()}>
                 <p class="max-w-[20rem] text-neutral-400">
                     {i18n.t("error.load_time.stuck")}{" "}
-                    <A class="text-white" href="/emergencykit">
+                    <A class="text-white" href="/settings/emergencykit">
                         {i18n.t("error.emergency_link")}
                     </A>
                 </p>

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -76,11 +76,15 @@ export default function Root() {
             <Body>
                 <Suspense>
                     <ErrorBoundary fallback={(e) => <ErrorDisplay error={e} />}>
-                        <I18nProvider>
-                            <MegaStoreProvider>
-                                <Router />
-                            </MegaStoreProvider>
-                        </I18nProvider>
+                        <MegaStoreProvider>
+                            <I18nProvider>
+                                <ErrorBoundary
+                                    fallback={(e) => <ErrorDisplay error={e} />}
+                                >
+                                    <Router />
+                                </ErrorBoundary>
+                            </I18nProvider>
+                        </MegaStoreProvider>
                     </ErrorBoundary>
                 </Suspense>
                 <Scripts />


### PR DESCRIPTION
No totally sure what I am doing here but I think this could help.

When `MegaStoreProvider` is mounted it creates an instance of mutiny-node, so if any parent components are changed it would too. So I put the `I18nProvider` inside of it incase that is changing as well as a second `ErrorBoundary` that will handle the `Router`, so if any uncaught errors happen there, we don't create a new instance of mutiny-node.

ChatGPT said it might help