### PR TITLE
Hide lightning swap button if on-chain balance is only force closes

### DIFF
--- a/src/components/BalanceBox.tsx
+++ b/src/components/BalanceBox.tsx
@@ -52,6 +52,9 @@ export function BalanceBox(props: { loading?: boolean }) {
         (state.balance?.unconfirmed || 0n) +
         (state.balance?.force_close || 0n);
 
+    const usableOnchain = () =>
+        (state.balance?.confirmed || 0n) + (state.balance?.unconfirmed || 0n);
+
     return (
         <>
             <FancyCard>
@@ -115,7 +118,7 @@ export function BalanceBox(props: { loading?: boolean }) {
                             <Show when={state.balance?.unconfirmed === 0n}>
                                 <div />
                             </Show>
-                            <Show when={totalOnchain() != 0n}>
+                            <Show when={usableOnchain() > 0n}>
                                 <div class="self-end justify-self-end">
                                     <A href="/swap" class={STYLE}>
                                         <img


### PR DESCRIPTION
A lot of users get confused after a force close they click the swap button but then have 0 balance there. We should only show the button if they have an actual balance, not pending force closes