### PR TITLE
don't throw for failed zap parse

### DIFF
--- a/src/utils/fetchZaps.ts
+++ b/src/utils/fetchZaps.ts
@@ -201,9 +201,13 @@ export const fetchZaps: ResourceFetcher<
 
     for (const object of data) {
         if (object.kind === 10000113) {
-            const content = JSON.parse(object.content);
-            if (content?.until) {
-                newUntil = content?.until + 1;
+            try {
+                const content = JSON.parse(object.content);
+                if (content?.until) {
+                    newUntil = content?.until + 1;
+                }
+            } catch (e) {
+                console.error("Failed to parse content: ", object.content);
             }
         }
 
@@ -212,14 +216,18 @@ export const fetchZaps: ResourceFetcher<
         }
 
         if (object.kind === 9735) {
-            const event = await simpleZapFromEvent(
-                object,
-                state.mutiny_wallet!
-            );
+            try {
+                const event = await simpleZapFromEvent(
+                    object,
+                    state.mutiny_wallet!
+                );
 
-            // Only add it if it's a valid zap (not undefined)
-            if (event) {
-                zaps.push(event);
+                // Only add it if it's a valid zap (not undefined)
+                if (event) {
+                    zaps.push(event);
+                }
+            } catch (e) {
+                console.error("Failed to parse zap event: ", object);
             }
         }
     }


### PR DESCRIPTION
don't have to halt everything for this error, now we catch it and continue:

<img width="927" alt="Screenshot 2023-11-08 at 12 37 54 PM" src="https://github.com/MutinyWallet/mutiny-web/assets/543668/db017d0b-a9f0-4f83-b4b9-f45ad2648f66">

here's an example event we were choking on before idk what's specifically wrong with it I don't have nostr loaded into my brain rn
<img width="936" alt="Screenshot 2023-11-08 at 12 34 11 PM" src="https://github.com/MutinyWallet/mutiny-web/assets/543668/4b47c091-0df9-4dd2-9b62-1531c9c72cb7">
