### PR TITLE
fix spacing for fiat amounts

### DIFF
--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -89,7 +89,7 @@ export function AmountFiat(props: {
                     "text-xl": props.denominationSize === "xl"
                 }}
             >
-                {`${state.fiat.value} `}
+                {` ${state.fiat.value} `}
             </span>
         </h2>
     );


### PR DESCRIPTION
this fixes a regression from #520 

good:
<img width="148" alt="Screenshot 2023-11-08 at 3 50 35 PM" src="https://github.com/MutinyWallet/mutiny-web/assets/543668/4153f163-de6c-48b4-8782-971f0944ab14">

bad:
<img width="152" alt="Screenshot 2023-11-08 at 3 50 29 PM" src="https://github.com/MutinyWallet/mutiny-web/assets/543668/4dc5cddb-23d0-4dec-ba98-e5ffc9177a21">

