### PR TITLE
Playwright CI improvements

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,11 @@
 name: Playwright Tests
+
+# Only run one at a time per branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
-  push:
-    branches:
-      - master
-      - prod
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
Makes it so we will only run on PRs (no reason to run it on merge)

Also makes it so only one will run at a time per PR, this way we'll have a higher likelihood of things not getting borked