### PR TITLE
refactor zap fetch and discard non-pubkeys

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1434;
 				DEVELOPMENT_TEAM = X773Y823TN;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -376,7 +376,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1434;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = X773Y823TN;
 				INFOPLIST_FILE = App/Info.plist;

--- a/src/utils/fetchZaps.ts
+++ b/src/utils/fetchZaps.ts
@@ -143,12 +143,16 @@ async function fetchFollows(npub: string): Promise<string[]> {
     const data = await response.json();
 
     const follows: string[] = [];
+    const pubkeyRegex = new RegExp(/[0-9a-fA-F]{64}/);
 
     for (const event of data) {
         if (event.kind === 3) {
             for (const tag of event.tags) {
                 if (tag[0] === "p") {
-                    follows.push(tag[1]);
+                    // make sure it's actually a pubkey
+                    if (pubkeyRegex.test(tag[1])) {
+                        follows.push(tag[1]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
this refactors a bit to make nostr fetching easier to read and catches the error in #710 but doesn't solve it

update: now it does solve it. problem was a user had non-pubkeys in their list of follows