### PR TITLE
Add hodl invoice warning

### DIFF
--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -126,7 +126,9 @@ export default {
         error_LNURL: "LNURL Pay failed",
         payment_pending: "Payment pending",
         payment_pending_description:
-            "It's taking a while, but it's possible this payment may still go through. Please check 'Activity' for the current status."
+            "It's taking a while, but it's possible this payment may still go through. Please check 'Activity' for the current status.",
+        hodl_invoice_warning:
+            "This is a hodl invoice. Payments to hodl invoices can cause in channel force closes, which results in high on-chain fees. Pay at your own risk!"
     },
     feedback: {
         header: "Give us feedback!",

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -244,6 +244,8 @@ export default function Send() {
     const [address, setAddress] = createSignal<string>();
     const [description, setDescription] = createSignal<string>();
 
+    const [isHodlInvoice, setIsHodlInvoice] = createSignal<boolean>(false);
+
     // Is sending / sent
     const [sending, setSending] = createSignal(false);
     const [sentDetails, setSentDetails] = createSignal<SentDetails>();
@@ -398,6 +400,7 @@ export default function Send() {
                             setIsAmtEditable(false);
                         }
                         setInvoice(invoice);
+                        setIsHodlInvoice(invoice.potential_hodl_invoice);
                         setSource("lightning");
                     });
             } else if (source.node_pubkey) {
@@ -759,6 +762,15 @@ export default function Send() {
                                     isAmountEditable={isAmtEditable()}
                                     maxAmountSats={maxAmountSats()}
                                 />
+                                <Show when={isHodlInvoice()}>
+                                    <InfoBox accent="red">
+                                        <p>
+                                            {i18n.t(
+                                                "send.hodl_invoice_warning"
+                                            )}
+                                        </p>
+                                    </InfoBox>
+                                </Show>
                                 <Show when={error()}>
                                     <InfoBox accent="red">
                                         <p>{error()}</p>


### PR DESCRIPTION
To test I just added the signet lsp to the list of hodl invoice nodes
![image](https://github.com/MutinyWallet/mutiny-web/assets/15256660/eb22724b-d24e-4f7b-aade-ee9ea4bb4a22)
