### PR TITLE
Show lightning address on send screen

### DIFF
--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -128,7 +128,7 @@ export default {
         payment_pending_description:
             "It's taking a while, but it's possible this payment may still go through. Please check 'Activity' for the current status.",
         hodl_invoice_warning:
-            "This is a hodl invoice. Payments to hodl invoices can cause in channel force closes, which results in high on-chain fees. Pay at your own risk!"
+            "This is a hodl invoice. Payments to hodl invoices can cause channel force closes, which results in high on-chain fees. Pay at your own risk!"
     },
     feedback: {
         header: "Give us feedback!",

--- a/src/logic/waila.ts
+++ b/src/logic/waila.ts
@@ -14,6 +14,7 @@ export type ParsedParams = {
     privateTag?: string;
     node_pubkey?: string;
     lnurl?: string;
+    lightning_address?: string;
 };
 
 export function toParsedParams(
@@ -54,7 +55,8 @@ export function toParsedParams(
             network,
             memo: params.memo,
             node_pubkey: params.node_pubkey,
-            lnurl: params.lnurl
+            lnurl: params.lnurl,
+            lightning_address: params.lightning_address
         }
     };
 }

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -179,6 +179,7 @@ function DestinationShower(props: {
     invoice?: MutinyInvoice;
     nodePubkey?: string;
     lnurl?: string;
+    lightning_address?: string;
     clearAll: () => void;
 }) {
     return (
@@ -192,7 +193,18 @@ function DestinationShower(props: {
             <Match when={props.nodePubkey && props.source === "lightning"}>
                 <StringShower text={props.nodePubkey || ""} />
             </Match>
-            <Match when={props.lnurl && props.source === "lightning"}>
+            <Match
+                when={props.lightning_address && props.source === "lightning"}
+            >
+                <StringShower text={props.lightning_address || ""} />
+            </Match>
+            <Match
+                when={
+                    props.lnurl &&
+                    !props.lightning_address &&
+                    props.source === "lightning"
+                }
+            >
                 <StringShower text={props.lnurl || ""} />
             </Match>
         </Switch>
@@ -241,6 +253,7 @@ export default function Send() {
     const [invoice, setInvoice] = createSignal<MutinyInvoice>();
     const [nodePubkey, setNodePubkey] = createSignal<string>();
     const [lnurlp, setLnurlp] = createSignal<string>();
+    const [lnAddress, setLnAddress] = createSignal<string>();
     const [address, setAddress] = createSignal<string>();
     const [description, setDescription] = createSignal<string>();
 
@@ -267,12 +280,14 @@ export default function Send() {
         setDestination(undefined);
         setAmountSats(0n);
         setIsAmtEditable(true);
+        setIsHodlInvoice(false);
         setSource("lightning");
         setInvoice(undefined);
         setAddress(undefined);
         setDescription(undefined);
         setNodePubkey(undefined);
         setLnurlp(undefined);
+        setLnAddress(undefined);
         setFieldDestination("");
     }
 
@@ -418,6 +433,18 @@ export default function Send() {
                             } else {
                                 setAmountSats(source.amount_sats || 0n);
                             }
+
+                            // If it is a lightning address, set the address so we can display it
+                            if (source.lightning_address) {
+                                setLnAddress(source.lightning_address);
+                                // check for hodl invoices
+                                setIsHodlInvoice(
+                                    source.lightning_address
+                                        .toLowerCase()
+                                        .includes("zeuspay.com")
+                                );
+                            }
+
                             setLnurlp(source.lnurl);
                             setSource("lightning");
                         }
@@ -736,6 +763,7 @@ export default function Send() {
                                             address={address()}
                                             nodePubkey={nodePubkey()}
                                             lnurl={lnurlp()}
+                                            lightning_address={lnAddress()}
                                             clearAll={clearAll}
                                         />
                                         <SmallHeader>

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -196,7 +196,9 @@ function DestinationShower(props: {
             <Match
                 when={props.lightning_address && props.source === "lightning"}
             >
-                <StringShower text={props.lightning_address || ""} />
+                <span class="overflow-hidden overflow-ellipsis whitespace-nowrap font-mono">
+                    {props.lightning_address || ""}
+                </span>
             </Match>
             <Match
                 when={


### PR DESCRIPTION
Before if you entered a lightning address the destination would be it lnurl encoded, this will fix for it so show as the normal lightning address.

Also adds the is hodl invoice check for zeuspay addresses

![image](https://github.com/MutinyWallet/mutiny-web/assets/15256660/7eefc17d-0d1a-448c-b440-aa8d4c636859)
