### PR TITLE
Reload page on Wasm error

### DIFF
--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -38,6 +38,9 @@ export function ErrorDisplay(props: { error: Error }) {
                         {i18n.t("error.general.support_link")}
                     </ExternalLink>
                 </NiceP>
+                <Button onClick={() => window.location.reload()}>
+                    {i18n.t("error.reload")}
+                </Button>
                 <NiceP>
                     {i18n.t("error.general.getting_desperate")}{" "}
                     <A href="/settings/emergencykit">


### PR DESCRIPTION
When we get this error you just need to refresh the page, so we can just do it automatically.

One potential issue is that if refreshing doesn't fix, it'll be in a refresh loop

![image](https://github.com/MutinyWallet/mutiny-web/assets/15256660/c46e5003-d8e1-498a-abe3-b5067b536599)
