### PR TITLE
Fix nginx for other routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ FROM nginx:alpine
 # Copy the static assets from the builder stage to the Nginx default static serve directory
 COPY --from=builder /app/dist/public /usr/share/nginx/html
 
+# Copy the custom Nginx configuration file into the container
+COPY default.conf /etc/nginx/conf.d/default.conf
+
 # Expose the default Nginx port
 EXPOSE 80
 

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Previously if you went to any route that wasn't `/` on a self hosted instance it would fail unless you originally navigated from the `/` route. This fixes so those routes will fallback to the `index.html` so it can get the correct page