### PR TITLE
multi lsp

### DIFF
--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -511,6 +511,17 @@ export default {
             lsp_label: "LSP",
             lsp_caption:
                 "Lightning Service Provider. Automatically opens channels to you for inbound liquidity. Also wraps invoices for privacy.",
+            lsps_connection_string_label: "LSPS Connection String",
+            lsps_connection_string_caption:
+                "Lightning Service Provider. Automatically opens channels to you for inbound liquidity. Using LSP specification.",
+            error_lsps_connection_string:
+                "That doesn't look like node connection string",
+            lsps_token_label: "LSPS Token",
+            lsps_token_caption:
+                "LSPS Token.  Used to identify what wallet is connecting to the LSP",
+            lsps_valid_error:
+                "You can either have just an LSP set or LSPS Connection String and LSPS Token set, not both.",
+            error_lsps_token: "That doesn't look like a valid token",
             storage_label: "Storage",
             storage_caption: "Encrypted VSS backup service.",
             error_lsp: "That doesn't look like a URL",

--- a/src/logic/mutinyWalletSetup.ts
+++ b/src/logic/mutinyWalletSetup.ts
@@ -10,6 +10,8 @@ export type MutinyWalletSettingStrings = {
     esplora?: string;
     rgs?: string;
     lsp?: string;
+    lsps_connection_string?: string;
+    lsps_token?: string;
     auth?: string;
     subscriptions?: string;
     storage?: string;
@@ -42,6 +44,16 @@ const SETTINGS_KEYS = [
         name: "lsp",
         storageKey: "USER_SETTINGS_lsp",
         default: import.meta.env.VITE_LSP
+    },
+    {
+        name: "lsps_connection_string",
+        storageKey: "USER_SETTINGS_lsps_connection_string",
+        default: import.meta.env.VITE_LSPS_CONNECTION_STRING
+    },
+    {
+        name: "lsps_token",
+        storageKey: "USER_SETTINGS_lsps_token",
+        default: import.meta.env.VITE_LSPS_TOKEN
     },
     {
         name: "auth",
@@ -229,6 +241,8 @@ export async function setupMutinyWallet(
         esplora,
         rgs,
         lsp,
+        lsps_connection_string,
+        lsps_token,
         auth,
         subscriptions,
         storage,
@@ -241,12 +255,17 @@ export async function setupMutinyWallet(
     console.log("Using esplora address", esplora);
     console.log("Using rgs address", rgs);
     console.log("Using lsp address", lsp);
+    console.log("Using lsp connection string", lsps_connection_string);
+    console.log("Using lsp token", lsps_token);
     console.log("Using auth address", auth);
     console.log("Using subscriptions address", subscriptions);
     console.log("Using storage address", storage);
     console.log("Using scorer address", scorer);
     console.log(safeMode ? "Safe mode enabled" : "Safe mode disabled");
     console.log(shouldZapHodl ? "Hodl zaps enabled" : "Hodl zaps disabled");
+
+    // Only use lsps if there's no lsp set
+    const shouldUseLSPS = !lsp && lsps_connection_string && lsps_token;
 
     const mutinyWallet = await new MutinyWallet(
         // Password
@@ -258,10 +277,8 @@ export async function setupMutinyWallet(
         esplora,
         rgs,
         lsp,
-        // LSPS connection string
-        undefined,
-        // LSPS token
-        undefined,
+        shouldUseLSPS ? lsps_connection_string : undefined,
+        shouldUseLSPS ? lsps_token : undefined,
         auth,
         subscriptions,
         storage,


### PR DESCRIPTION
my version of #748

relies on https://github.com/MutinyWallet/mutiny-node/pull/894

I think we might need some better facility for "switching" lsp in mutiny-node. We can't make the lsps stuff default yet, so that means a wallet and node spin up at launch with flow 2.0 and apparently that locks the wallet to only using the original lsp that's set.