### PR TITLE
switch Contact to TagItem, handle edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@kobalte/core": "^0.9.8",
         "@kobalte/tailwindcss": "^0.5.0",
         "@modular-forms/solid": "^0.18.1",
-        "@mutinywallet/mutiny-wasm": "0.4.39",
+        "@mutinywallet/mutiny-wasm": "0.5.0-rc1",
         "@mutinywallet/waila-wasm": "^0.2.6",
         "@solid-primitives/upload": "^0.0.111",
         "@solid-primitives/websocket": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(solid-js@1.8.5)
       '@mutinywallet/mutiny-wasm':
-        specifier: 0.4.39
-        version: 0.4.39
+        specifier: 0.5.0-rc1
+        version: 0.5.0-rc1
       '@mutinywallet/waila-wasm':
         specifier: ^0.2.6
         version: 0.2.6
@@ -2584,8 +2584,8 @@ packages:
       solid-js: 1.8.5
     dev: false
 
-  /@mutinywallet/mutiny-wasm@0.4.39:
-    resolution: {integrity: sha512-7vMgwteU0lCzMdX/INIIlsrq5jvEJA2aXuJmqHzGb6Bgty2jOfuWVvW54c2SZ3HQvuFHDPxjrrDB2QHabdBhMw==}
+  /@mutinywallet/mutiny-wasm@0.5.0-rc1:
+    resolution: {integrity: sha512-UTkLbJ+Hux79IoJqRwVVSxZng94ALkx89NXtYU69WzplPOHoIk/jFrjAXzLQK9MXu1dqsePu/yeAOwCumRkMPw==}
     dev: false
 
   /@mutinywallet/waila-wasm@0.2.6:

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -1,4 +1,4 @@
-import { Contact } from "@mutinywallet/mutiny-wasm";
+import { TagItem } from "@mutinywallet/mutiny-wasm";
 import { A } from "@solidjs/router";
 import {
     createEffect,
@@ -36,7 +36,7 @@ export interface IActivityItem {
     amount_sats: number;
     inbound: boolean;
     labels: string[];
-    contacts: Contact[];
+    contacts: TagItem[];
     last_updated: number;
 }
 

--- a/src/components/ActivityItem.tsx
+++ b/src/components/ActivityItem.tsx
@@ -1,4 +1,4 @@
-import { Contact } from "@mutinywallet/mutiny-wasm";
+import { TagItem } from "@mutinywallet/mutiny-wasm";
 import { createResource, Match, ParentComponent, Switch } from "solid-js";
 
 import bolt from "~/assets/icons/bolt.svg";
@@ -97,7 +97,7 @@ export type HackActivityType =
 export function ActivityItem(props: {
     // This is actually the ActivityType enum but wasm is hard
     kind: HackActivityType;
-    contacts: Contact[];
+    contacts: TagItem[];
     labels: string[];
     amount: number | bigint;
     date?: number | bigint;

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,4 +1,9 @@
-import { createForm, required, SubmitHandler } from "@modular-forms/solid";
+import {
+    createForm,
+    email,
+    required,
+    SubmitHandler
+} from "@modular-forms/solid";
 
 import {
     Button,
@@ -42,11 +47,20 @@ export function ContactForm(props: {
                             />
                         )}
                     </Field>
-                    {/* <Field name="npub" validate={[]}>
+                    <Field
+                        name="ln_address"
+                        validate={[email(i18n.t("contacts.email_error"))]}
+                    >
                         {(field, props) => (
-                            <TextField  {...props} placeholder='npub...' value={field.value} error={field.error} label="Nostr npub or NIP-05 (optional)" />
+                            <TextField
+                                {...props}
+                                placeholder="example@example.com"
+                                value={field.value}
+                                error={field.error}
+                                label={i18n.t("contacts.ln_address")}
+                            />
                         )}
-                    </Field> */}
+                    </Field>
                 </VStack>
             </div>
             <VStack>

--- a/src/components/ContactViewer.tsx
+++ b/src/components/ContactViewer.tsx
@@ -1,6 +1,6 @@
 import { Dialog } from "@kobalte/core";
 import { SubmitHandler } from "@modular-forms/solid";
-import { Contact } from "@mutinywallet/mutiny-wasm";
+import { TagItem } from "@mutinywallet/mutiny-wasm";
 import { useNavigate } from "@solidjs/router";
 import { createSignal, Match, Show, Switch } from "solid-js";
 
@@ -22,12 +22,13 @@ import { DIALOG_CONTENT, DIALOG_POSITIONER } from "~/styles/dialogs";
 export type ContactFormValues = {
     name: string;
     npub?: string;
+    ln_address?: string;
 };
 
 export function ContactViewer(props: {
-    contact: Contact;
+    contact: TagItem;
     gradient: string;
-    saveContact: (contact: Contact) => void;
+    saveContact: (id: string, contact: ContactFormValues) => void;
 }) {
     const i18n = useI18n();
     const [isOpen, setIsOpen] = createSignal(false);
@@ -38,10 +39,9 @@ export function ContactViewer(props: {
     const handleSubmit: SubmitHandler<ContactFormValues> = (
         c: ContactFormValues
     ) => {
-        // FIXME: merge with existing contact if saving (need edit contact method)
-        // FIXME: npub not valid? other undefineds
-        const contact = new Contact(c.name, undefined, undefined, undefined);
-        props.saveContact(contact);
+        const id = props.contact.id;
+
+        props.saveContact(id, c);
         setIsEditing(false);
     };
 
@@ -201,7 +201,7 @@ export function ContactViewer(props: {
                                     </div>
 
                                     {/* TODO: implement contact editing */}
-                                    {/* <div class="flex w-full gap-2">
+                                    <div class="flex w-full gap-2">
                                         <Button
                                             layout="flex"
                                             intent="green"
@@ -209,10 +209,6 @@ export function ContactViewer(props: {
                                         >
                                             {i18n.t("contacts.edit")}
                                         </Button>
-
-                                    </div> */}
-
-                                    <div class="flex w-full">
                                         <Button
                                             intent="blue"
                                             disabled={

--- a/src/components/KitchenSink.tsx
+++ b/src/components/KitchenSink.tsx
@@ -39,19 +39,10 @@ function PeerItem(props: { peer: MutinyPeer }) {
     const [state, _] = useMegaStore();
 
     const handleDisconnectPeer = async () => {
-        const nodes = await state.mutiny_wallet?.list_nodes();
-        const firstNode = (nodes[0] as string) || "";
-
         if (props.peer.is_connected) {
-            await state.mutiny_wallet?.disconnect_peer(
-                firstNode,
-                props.peer.pubkey
-            );
+            await state.mutiny_wallet?.disconnect_peer(props.peer.pubkey);
         } else {
-            await state.mutiny_wallet?.delete_peer(
-                firstNode,
-                props.peer.pubkey
-            );
+            await state.mutiny_wallet?.delete_peer(props.peer.pubkey);
         }
     };
 
@@ -132,13 +123,8 @@ function ConnectPeer(props: { refetchPeers: RefetchPeersType }) {
         e.preventDefault();
 
         const peerConnectString = value().trim();
-        const nodes = await state.mutiny_wallet?.list_nodes();
-        const firstNode = (nodes[0] as string) || "";
 
-        await state.mutiny_wallet?.connect_to_peer(
-            firstNode,
-            peerConnectString
-        );
+        await state.mutiny_wallet?.connect_to_peer(peerConnectString);
 
         await props.refetchPeers();
 
@@ -353,11 +339,7 @@ function OpenChannel(props: { refetchChannels: RefetchChannelsListType }) {
             const pubkey = peerPubkey().trim();
             const bigAmount = BigInt(amount());
 
-            const nodes = await state.mutiny_wallet?.list_nodes();
-            const firstNode = (nodes[0] as string) || "";
-
             const new_channel = await state.mutiny_wallet?.open_channel(
-                firstNode,
                 pubkey,
                 bigAmount
             );

--- a/src/components/NWCEditor.tsx
+++ b/src/components/NWCEditor.tsx
@@ -5,7 +5,7 @@ import {
     setValue,
     SubmitHandler
 } from "@modular-forms/solid";
-import { BudgetPeriod, Contact, NwcProfile } from "@mutinywallet/mutiny-wasm";
+import { BudgetPeriod, NwcProfile, TagItem } from "@mutinywallet/mutiny-wasm";
 import {
     createMemo,
     createResource,
@@ -192,7 +192,7 @@ export function NWCEditor(props: {
     );
 
     // TODO: this should get the contact so we can get the image, but not getting a contact tagged on the nwc right now
-    const contactFetcher: ResourceFetcher<string, Contact | undefined> = async (
+    const contactFetcher: ResourceFetcher<string, TagItem | undefined> = async (
         label,
         _last
     ) => {
@@ -200,8 +200,8 @@ export function NWCEditor(props: {
         if (!label) return undefined;
 
         try {
-            const contact: Contact | undefined =
-                await state.mutiny_wallet?.get_contact(label);
+            const contact: TagItem | undefined =
+                await state.mutiny_wallet?.get_tag_item(label);
             return contact;
         } catch (e) {
             console.error(e);

--- a/src/components/PendingNwc.tsx
+++ b/src/components/PendingNwc.tsx
@@ -75,8 +75,7 @@ export function PendingNwc() {
     async function payItem(item: PendingItem) {
         try {
             setPaying(item.id);
-            const nodes = await state.mutiny_wallet?.list_nodes();
-            await state.mutiny_wallet?.approve_invoice(item.id, nodes[0]);
+            await state.mutiny_wallet?.approve_invoice(item.id);
             await vibrateSuccess();
         } catch (e) {
             setError(eify(e));

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -36,11 +36,13 @@ export default {
         edit: "Edit",
         pay: "Pay",
         name: "Name",
+        ln_address: "Lightning Address",
         placeholder: "Satoshi",
         lightning_address: "Lightning Address",
         unimplemented: "Unimplemented",
         not_available: "We don't do that yet",
-        error_name: "We at least need a name"
+        error_name: "We at least need a name",
+        email_error: "That doesn't look like a lightning address"
     },
     receive: {
         receive_bitcoin: "Receive Bitcoin",

--- a/src/logic/mutinyWalletSetup.ts
+++ b/src/logic/mutinyWalletSetup.ts
@@ -258,6 +258,10 @@ export async function setupMutinyWallet(
         esplora,
         rgs,
         lsp,
+        // LSPS connection string
+        undefined,
+        // LSPS token
+        undefined,
         auth,
         subscriptions,
         storage,

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -1,7 +1,6 @@
 /* @refresh reload */
 
 import {
-    Contact,
     MutinyBip21RawMaterials,
     MutinyInvoice,
     TagItem
@@ -219,15 +218,11 @@ export function Receive() {
             }
 
             if (!first.id && first.name) {
-                const c = new Contact(
-                    first.name,
-                    undefined,
-                    undefined,
-                    undefined
-                );
                 try {
                     const newContactId =
-                        await state.mutiny_wallet?.create_new_contact(c);
+                        await state.mutiny_wallet?.create_new_contact(
+                            first.name
+                        );
                     if (newContactId) {
                         return [newContactId];
                     }

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -573,13 +573,10 @@ export function Send() {
             const tags = await processContacts(selectedContacts());
 
             if (source() === "lightning" && invoice() && bolt11) {
-                const nodes = await state.mutiny_wallet?.list_nodes();
-                const firstNode = (nodes[0] as string) || "";
                 sentDetails.destination = bolt11;
                 // If the invoice has sats use that, otherwise we pass the user-defined amount
                 if (invoice()?.amount_sats) {
                     const payment = await state.mutiny_wallet?.pay_invoice(
-                        firstNode,
                         bolt11,
                         undefined,
                         tags
@@ -589,7 +586,6 @@ export function Send() {
                     sentDetails.fee_estimate = payment?.fees_paid || 0;
                 } else {
                     const payment = await state.mutiny_wallet?.pay_invoice(
-                        firstNode,
                         bolt11,
                         amountSats(),
                         tags
@@ -599,10 +595,7 @@ export function Send() {
                     sentDetails.fee_estimate = payment?.fees_paid || 0;
                 }
             } else if (source() === "lightning" && nodePubkey()) {
-                const nodes = await state.mutiny_wallet?.list_nodes();
-                const firstNode = (nodes[0] as string) || "";
                 const payment = await state.mutiny_wallet?.keysend(
-                    firstNode,
                     nodePubkey()!,
                     amountSats(),
                     undefined, // todo add optional keysend message
@@ -618,10 +611,7 @@ export function Send() {
                     sentDetails.fee_estimate = payment?.fees_paid || 0;
                 }
             } else if (source() === "lightning" && lnurlp()) {
-                const nodes = await state.mutiny_wallet?.list_nodes();
-                const firstNode = (nodes[0] as string) || "";
                 const payment = await state.mutiny_wallet?.lnurl_pay(
-                    firstNode,
                     lnurlp()!,
                     amountSats(),
                     undefined, // zap_npub

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -1,6 +1,6 @@
 import { Clipboard } from "@capacitor/clipboard";
 import { Capacitor } from "@capacitor/core";
-import { Contact, MutinyInvoice, TagItem } from "@mutinywallet/mutiny-wasm";
+import { MutinyInvoice, TagItem } from "@mutinywallet/mutiny-wasm";
 import { A, useNavigate, useSearchParams } from "@solidjs/router";
 import {
     createEffect,
@@ -539,15 +539,11 @@ export function Send() {
             }
 
             if (!first.id && first.name) {
-                const c = new Contact(
-                    first.name,
-                    undefined,
-                    undefined,
-                    undefined
-                );
                 try {
                     const newContactId =
-                        await state.mutiny_wallet?.create_new_contact(c);
+                        await state.mutiny_wallet?.create_new_contact(
+                            first.name
+                        );
                     if (newContactId) {
                         return [newContactId];
                     }

--- a/src/routes/Swap.tsx
+++ b/src/routes/Swap.tsx
@@ -116,13 +116,8 @@ export function Swap() {
         setIsConnecting(true);
         try {
             const peerConnectString = values.peer.trim();
-            const nodes = await state.mutiny_wallet?.list_nodes();
-            const firstNode = (nodes[0] as string) || "";
 
-            await state.mutiny_wallet?.connect_to_peer(
-                firstNode,
-                peerConnectString
-            );
+            await state.mutiny_wallet?.connect_to_peer(peerConnectString);
 
             await refetch();
 
@@ -156,8 +151,6 @@ export function Swap() {
         if (canSwap()) {
             try {
                 setLoading(true);
-                const nodes = await state.mutiny_wallet?.list_nodes();
-                const firstNode = (nodes[0] as string) || "";
 
                 let peer = undefined;
 
@@ -167,15 +160,11 @@ export function Swap() {
 
                 if (isMax()) {
                     const new_channel =
-                        await state.mutiny_wallet?.sweep_all_to_channel(
-                            firstNode,
-                            peer
-                        );
+                        await state.mutiny_wallet?.sweep_all_to_channel(peer);
 
                     setChannelOpenResult({ channel: new_channel });
                 } else {
                     const new_channel = await state.mutiny_wallet?.open_channel(
-                        firstNode,
                         peer,
                         amountSats()
                     );

--- a/src/utils/gradientHash.ts
+++ b/src/utils/gradientHash.ts
@@ -1,4 +1,4 @@
-import { Contact } from "@mutinywallet/mutiny-wasm";
+import { TagItem } from "@mutinywallet/mutiny-wasm";
 
 export async function generateGradient(str: string) {
     const encoder = new TextEncoder();
@@ -13,7 +13,7 @@ export async function generateGradient(str: string) {
     return gradient;
 }
 
-export async function gradientsPerContact(contacts: Contact[]) {
+export async function gradientsPerContact(contacts: TagItem[]) {
     const gradients = new Map();
     for (const contact of contacts) {
         const gradient = await generateGradient(contact.name);


### PR DESCRIPTION
requires https://github.com/MutinyWallet/mutiny-node/pull/898

also this change allows us to do contact editing so I added a small amount of that (you can also add a lightning address when creating... good test is to add faucet as a contact: `refund@lnurl-staging.mutinywallet.com`)

didn't go crazy with other possibilities because contacts are going to shift around a lot in the new design