### PR TITLE
Drop MutinyWallet before restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@kobalte/core": "^0.9.8",
         "@kobalte/tailwindcss": "^0.5.0",
         "@modular-forms/solid": "^0.18.1",
-        "@mutinywallet/mutiny-wasm": "0.5.0-rc1",
+        "@mutinywallet/mutiny-wasm": "0.5.0-rc2",
         "@mutinywallet/waila-wasm": "^0.2.6",
         "@solid-primitives/upload": "^0.0.111",
         "@solid-primitives/websocket": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(solid-js@1.8.5)
       '@mutinywallet/mutiny-wasm':
-        specifier: 0.5.0-rc1
-        version: 0.5.0-rc1
+        specifier: 0.5.0-rc2
+        version: 0.5.0-rc2
       '@mutinywallet/waila-wasm':
         specifier: ^0.2.6
         version: 0.2.6
@@ -2584,8 +2584,8 @@ packages:
       solid-js: 1.8.5
     dev: false
 
-  /@mutinywallet/mutiny-wasm@0.5.0-rc1:
-    resolution: {integrity: sha512-UTkLbJ+Hux79IoJqRwVVSxZng94ALkx89NXtYU69WzplPOHoIk/jFrjAXzLQK9MXu1dqsePu/yeAOwCumRkMPw==}
+  /@mutinywallet/mutiny-wasm@0.5.0-rc2:
+    resolution: {integrity: sha512-LEx0WZgcSDYmAtUhUFzPFSVkkO6aXLPfAeDl7nRTxPSuzwZ7bAhDFcYtKRD/iGXOCETRBWgQ9ej1KquD4gJcBA==}
     dev: false
 
   /@mutinywallet/waila-wasm@0.2.6:

--- a/src/routes/settings/Restore.tsx
+++ b/src/routes/settings/Restore.tsx
@@ -134,6 +134,7 @@ function TwelveWordsEntry() {
                 console.log("Mutiny wallet loaded, stopping");
                 try {
                     await state.mutiny_wallet.stop();
+                    actions.dropMutinyWallet();
                 } catch (e) {
                     console.error(e);
                 }

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -93,6 +93,7 @@ export type MegaStore = [
         setBetaWarned(): void;
         setTestFlightPromptDismissed(): void;
         toggleHodl(): void;
+        dropMutinyWallet(): void;
     }
 ];
 
@@ -404,6 +405,9 @@ export const Provider: ParentComponent = (props) => {
             const should_zap_hodl = !state.should_zap_hodl;
             localStorage.setItem("should_zap_hodl", should_zap_hodl.toString());
             setState({ should_zap_hodl });
+        },
+        dropMutinyWallet() {
+            setState({ mutiny_wallet: undefined });
         }
     };
 


### PR DESCRIPTION
With gluedb, we need to drop all instances of it before trying to init it again. Since we're doing associated functions here, we need to init gluedb out of band since we don't rely on `MutinyWallet` anymore after we stop it. This makes sure we stop mutiny wallet and then drop it then do DB operations. 