### PR TITLE
Remove no-longer supported currencies + add new ones

### DIFF
--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -163,20 +163,9 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 0
     },
     {
-        label: "Kuwaiti Dinar KWD",
-        value: "KWD",
-        maxFractionalDigits: 3
-    },
-    {
         label: "Sri Lankan Rupee LKR",
         value: "LKR",
         hasSymbol: "Rs",
-        maxFractionalDigits: 2
-    },
-    {
-        label: "Myanmar Kyat MMK",
-        value: "MMK",
-        hasSymbol: "Ks",
         maxFractionalDigits: 2
     },
     {
@@ -273,12 +262,6 @@ export const FIAT_OPTIONS: Currency[] = [
         label: "Ukrainian Hryvnia UAH",
         value: "UAH",
         hasSymbol: "₴",
-        maxFractionalDigits: 2
-    },
-    {
-        label: "Venezuelan Bolívar VEF",
-        value: "VEF",
-        hasSymbol: "Bs",
         maxFractionalDigits: 2
     },
     {

--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -5,6 +5,8 @@ export interface Currency {
     maxFractionalDigits: number;
 }
 
+// When populating with new currencies it is recommended to get data from: https://www.xe.com/currency/usd-us-dollar/
+
 /**
  *  BTC_USD_OPTIONS is an array of BTC and USD currencies
  *  These are separated from the rest of the list for ease of access by the user and necessary access in the megaStore
@@ -48,6 +50,24 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Albanian Lek ALL",
+        value: "ALL",
+        hasSymbol: "Lek",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Dutch Guilder ANG",
+        value: "ANG",
+        hasSymbol: "ƒ",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Angolan Kwanza AOA",
+        value: "AOA",
+        hasSymbol: "Kz",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Argentine Peso ARS",
         value: "ARS",
         hasSymbol: "$",
@@ -60,9 +80,21 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Azerbaijan Manat AZN",
+        value: "AZN",
+        hasSymbol: "₼",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Bangladeshi Taka BDT",
         value: "BDT",
         hasSymbol: "৳",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Bulgarian Lev BGN",
+        value: "BGN",
+        hasSymbol: "лв",
         maxFractionalDigits: 2
     },
     {
@@ -72,9 +104,21 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 3
     },
     {
+        label: "Burundian Franc BIF",
+        value: "BIF",
+        hasSymbol: "Franc",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Bermuda Dollar BMD",
         value: "BMD",
         hasSymbol: "$",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Bolivian Bolíviano BOB",
+        value: "BOB",
+        hasSymbol: "$b",
         maxFractionalDigits: 2
     },
     {
@@ -84,10 +128,34 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Botswana Pula BWP",
+        value: "BWP",
+        hasSymbol: "P",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Belarusian Ruble BYN",
+        value: "BYN",
+        hasSymbol: "p.",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Belizean Dollar BZD",
+        value: "BZD",
+        hasSymbol: "BZ$",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Canadian Dollar CAD",
         value: "CAD",
         hasSymbol: "$",
         maxFractionalDigits: 2
+    },
+    {
+        label: "Congolese Franc CDF",
+        value: "CDF",
+        hasSymbol: "FC",
+        maxFractionalDigits: 0
     },
     { label: "Swiss Franc CHF", value: "CHF", maxFractionalDigits: 2 },
     {
@@ -103,15 +171,63 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Colombian Peso COP",
+        value: "COP",
+        hasSymbol: "$",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Costa Rican Colon CRC",
+        value: "CRC",
+        hasSymbol: "₡",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Cuban Peso CUP",
+        value: "CUP",
+        hasSymbol: "₱",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Czech Koruna CZK",
         value: "CZK",
         hasSymbol: "Kč",
         maxFractionalDigits: 2
     },
     {
+        label: "Djiboutian Franc DJF",
+        value: "DJF",
+        hasSymbol: "Franc",
+        maxFractionalDigits: 0
+    },
+    {
         label: "Danish Krone DKK",
         value: "DKK",
         hasSymbol: "kr",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Dominican Peso DOP",
+        value: "DOP",
+        hasSymbol: "RD$",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Algerian Dinar DZD",
+        value: "DZD",
+        hasSymbol: "DA",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Egyptian Pound EGP",
+        value: "EGP",
+        hasSymbol: "£",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Ethiopian Birr ETP",
+        value: "ETP",
+        hasSymbol: "Br",
         maxFractionalDigits: 2
     },
     {
@@ -127,15 +243,51 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Georgian Lari GEL",
+        value: "GEL",
+        hasSymbol: "Lari",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Ghanaian Cedi GHS",
+        value: "GHS",
+        hasSymbol: "₵",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Guinean Franc GNF",
+        value: "GNF",
+        hasSymbol: "Franc",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Guatemalan Quetzal GTQ",
+        value: "GTQ",
+        hasSymbol: "Q",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Hong Kong Dollar HKD",
         value: "HKD",
         hasSymbol: "$",
         maxFractionalDigits: 2
     },
     {
+        label: "Honduran Lempira HNL",
+        value: "HNL",
+        hasSymbol: "L",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Hungarian Forint HUF",
         value: "HUF",
         hasSymbol: "Ft",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Indonesian Rupiah IDR",
+        value: "IDR",
+        hasSymbol: "Rp",
         maxFractionalDigits: 2
     },
     {
@@ -151,9 +303,51 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Iranian Rial IRR",
+        value: "IRR",
+        hasSymbol: "﷼",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Iranian Toman IRT",
+        value: "IRT",
+        hasSymbol: "﷼",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Icelandic Krona ISK",
+        value: "ISK",
+        hasSymbol: "kr",
+        maxFractionalDigits: 0
+    },
+    {
+        label: "Jamaican Dollar JMD",
+        value: "JMD",
+        hasSymbol: "J$",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Jordanian Dinar JOD",
+        value: "JOD",
+        hasSymbol: "Dinar",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Japanese Yen JPY",
         value: "JPY",
         hasSymbol: "¥",
+        maxFractionalDigits: 0
+    },
+    {
+        label: "Kenyan Shilling KES",
+        value: "KES",
+        hasSymbol: "KSh",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Kyrgyzstani Som KGS",
+        value: "KGS",
+        hasSymbol: "лв",
         maxFractionalDigits: 0
     },
     {
@@ -163,10 +357,45 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 0
     },
     {
+        label: "Kazakhstani Tenge KZT",
+        value: "KZT",
+        hasSymbol: "₸",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Lebanese Pound LBP",
+        value: "LBP",
+        hasSymbol: "ل.ل",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Sri Lankan Rupee LKR",
         value: "LKR",
         hasSymbol: "Rs",
         maxFractionalDigits: 2
+    },
+    {
+        label: "Moroccan Dirham MAD",
+        value: "MAD",
+        hasSymbol: "Dirham",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Malagasy Ariary MGA",
+        value: "MGA",
+        hasSymbol: "Ar",
+        maxFractionalDigits: 1
+    },
+    {
+        label: "Cuban Peso MLC",
+        value: "MLC",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Mauritanian Ouguiya MRU",
+        value: "MRU",
+        hasSymbol: "UM",
+        maxFractionalDigits: 1
     },
     {
         label: "Mexican Peso MXN",
@@ -181,9 +410,9 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
-        label: "Norwegian Krone NOK",
-        value: "NOK",
-        hasSymbol: "kr",
+        label: "Namibian Dollar NAD",
+        value: "NAD",
+        hasSymbol: "$",
         maxFractionalDigits: 2
     },
     {
@@ -193,9 +422,39 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Nicaraguan Cordoba NIO",
+        value: "NIO",
+        hasSymbol: "C$",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Norwegian Krone NOK",
+        value: "NOK",
+        hasSymbol: "kr",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Nepalese Rupee NPR",
+        value: "NPR",
+        hasSymbol: "₨",
+        maxFractionalDigits: 2
+    },
+    {
         label: "New Zealand Dollar NZD",
         value: "NZD",
         hasSymbol: "$",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Panamanian Balboa PAB",
+        value: "PAB",
+        hasSymbol: "B/.",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Peruvian Sol PEN",
+        value: "PEN",
+        hasSymbol: "S/.",
         maxFractionalDigits: 2
     },
     {
@@ -217,9 +476,39 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Paraguayan Guarani PYG",
+        value: "PYG",
+        hasSymbol: "Gs",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Qatari Riyal QAR",
+        value: "QAR",
+        hasSymbol: "﷼",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Romanian Leu RON",
+        value: "RON",
+        hasSymbol: "lei",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Serbian Dinar RSD",
+        value: "RSD",
+        hasSymbol: "РСД",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Russian Ruble RUB",
         value: "RUB",
         hasSymbol: "₽",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Rwandan Franc RWF",
+        value: "RWF",
+        hasSymbol: "Franc",
         maxFractionalDigits: 2
     },
     {
@@ -247,6 +536,12 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Tunisian Dinar TND",
+        value: "TND",
+        hasSymbol: "Dinar",
+        maxFractionalDigits: 0
+    },
+    {
         label: "Turkish Lira TRY",
         value: "TRY",
         hasSymbol: "₺",
@@ -259,9 +554,38 @@ export const FIAT_OPTIONS: Currency[] = [
         maxFractionalDigits: 2
     },
     {
+        label: "Tanzanian Shilling TZS",
+        value: "TZS",
+        hasSymbol: "Shilling",
+        maxFractionalDigits: 2
+    },
+    {
         label: "Ukrainian Hryvnia UAH",
         value: "UAH",
         hasSymbol: "₴",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Ugandan Shilling UGX",
+        value: "UGX",
+        maxFractionalDigits: 0
+    },
+    {
+        label: "Uruguayan Peso UYU",
+        value: "UYU",
+        hasSymbol: "$U",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Uzbekistani Som UZS",
+        value: "UZS",
+        hasSymbol: "лв",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Venezuelan Bolívar VES",
+        value: "VES",
+        hasSymbol: "Bs",
         maxFractionalDigits: 2
     },
     {
@@ -269,6 +593,36 @@ export const FIAT_OPTIONS: Currency[] = [
         value: "VND",
         hasSymbol: "₫",
         maxFractionalDigits: 0
+    },
+    {
+        label: "Central African CFA Franc BEAC XAF",
+        value: "XAF",
+        hasSymbol: "FCFA",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Silver Ounce XAG",
+        value: "XAG",
+        hasSymbol: "Oz",
+        maxFractionalDigits: 6
+    },
+    {
+        label: "Gold Ounce XAU",
+        value: "XAU",
+        hasSymbol: "Oz",
+        maxFractionalDigits: 6
+    },
+    {
+        label: "CFA Franc XOF",
+        value: "XOF",
+        hasSymbol: "FCFA",
+        maxFractionalDigits: 2
+    },
+    {
+        label: "Platinum Ounce XPT",
+        value: "XPT",
+        hasSymbol: "Oz",
+        maxFractionalDigits: 6
     },
     {
         label: "South African Rand ZAR",


### PR DESCRIPTION
the new price api doesn't support these, these aren't huge countries so i think it is fine to remove for now, if someone complains we add another provider to the price api to bring them back

COP is now supported which a user requested: #639

test with: https://github.com/MutinyWallet/mutiny-node/pull/936