### PR TITLE
prettier formatting consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ just test-ui
 
 ### Formatting
 
-Hopefully your editor picks up on the `.prettirrc` file and auto formats accordingly. If you want to format everything in the project run `pnpm run format`.
+Hopefully your editor picks up on the `prettier.config.mjs` file and auto formats accordingly. If you want to format everything in the project run `pnpm run format`.
 
 ### Deploying Web
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,13 +1,13 @@
-import { CapacitorConfig } from '@capacitor/cli';
+import { CapacitorConfig } from "@capacitor/cli";
 
 const config: CapacitorConfig = {
-  appId: 'com.mutinywallet.mutinywallet',
-  backgroundColor: "171717",
-  appName: 'Mutiny Wallet',
-  webDir: 'dist/public',
-  server: {
-    androidScheme: 'https'
-  }
+    appId: "com.mutinywallet.mutinywallet",
+    backgroundColor: "171717",
+    appName: "Mutiny Wallet",
+    webDir: "dist/public",
+    server: {
+        androidScheme: "https"
+    }
 };
 
 export default config;

--- a/e2e/encrypt.spec.ts
+++ b/e2e/encrypt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("http://localhost:3420/");

--- a/e2e/load.spec.ts
+++ b/e2e/load.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:3420/");
+    await page.goto("http://localhost:3420/");
 });
 
 test("initial load", async ({ page }) => {
@@ -20,4 +20,3 @@ test("initial load", async ({ page }) => {
 
     console.log("Page loaded.");
 });
-

--- a/e2e/restore.spec.ts
+++ b/e2e/restore.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("http://localhost:3420/");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "check-types": "tsc --noemit",
         "eslint": "eslint src",
         "pre-commit": "pnpm run eslint && pnpm run check-types && pnpm run format",
-        "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
+        "format": "prettier --write \"{.,src/**,e2e/**}/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
         "check-format": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\""
     },
     "type": "module",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,19 +1,19 @@
 /** @type {import("prettier").Options} */
 export default {
-  trailingComma: "none",
-  tabWidth: 4,
-  semi: true,
-  singleQuote: false,
-  arrowParens: "always",
-  printWidth: 80,
-  useTabs: false,
+    trailingComma: "none",
+    tabWidth: 4,
+    semi: true,
+    singleQuote: false,
+    arrowParens: "always",
+    printWidth: 80,
+    useTabs: false,
 
-  plugins: [
-    "@ianvs/prettier-plugin-sort-imports",
-    "prettier-plugin-tailwindcss", // MUST come last
-  ],
+    plugins: [
+        "@ianvs/prettier-plugin-sort-imports",
+        "prettier-plugin-tailwindcss" // MUST come last
+    ],
 
-  tailwindFunctions: ["classList"],
+    tailwindFunctions: ["classList"],
 
-  importOrder: ["<THIRD_PARTY_MODULES>", "", "^[~/]", "", "^[./]"],
+    importOrder: ["<THIRD_PARTY_MODULES>", "", "^[~/]", "", "^[./]"]
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
         "vite.config.ts",
         ".eslintrc.cjs",
         "e2e/**/*",
-        "capacitor.config.ts"
+        "capacitor.config.ts",
+        "prettier.config.mjs"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
# What
- [x] ensure `format` script applies to all root files and `e2e/` as well as `src/`
- [x] include `prettier.config.mjs` in tsconfig to avoid eslint complaint in `prettier.config.mjs`
- [x] apply new format script
- [x] readme typo


Also  WHY `tabWidth: 4,` ? :D :D :D  my eyes...
