### PR TITLE
Lnurl withdrawal support

### DIFF
--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -113,7 +113,8 @@ export default {
             gift: "Lightning Gift"
         },
         remember_choice: "Remember my choice next time",
-        what_for: "What's this for?"
+        what_for: "What's this for?",
+        lnurl_withdrawal_in_progress: "LNUrl withdrawal in progress"
     },
     send: {
         search: {

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -114,7 +114,9 @@ export default {
         },
         remember_choice: "Remember my choice next time",
         what_for: "What's this for?",
-        lnurl_withdrawal_in_progress: "LNUrl withdrawal in progress"
+        lnurl_withdrawal_in_progress: "LNUrl withdrawal in progress",
+        lnurl_amount_message:
+            "Enter LNUrl withdrawal amount between min: {{min}} and max: {{max}}"
     },
     send: {
         search: {

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -402,10 +402,9 @@ export function Receive() {
         min: bigint,
         max: bigint
     ): string | undefined {
-        console.log("validateAmount", amount, min, max);
         if (amount === 0n) return "amount is zero";
         if (amount < min) return "amount smaller min";
-        if (amount > max * 1000n) return "amount greater max";
+        if (amount > max) return "amount greater max";
     }
 
     function mSatsToSats(mSats: bigint) {

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -1,7 +1,6 @@
 /* @refresh reload */
 
 import {
-    LnUrlParams,
     MutinyBip21RawMaterials,
     MutinyInvoice
 } from "@mutinywallet/mutiny-wasm";

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -136,9 +136,14 @@ export function Receive() {
     const [detailsOpen, setDetailsOpen] = createSignal(false);
     const [detailsKind, setDetailsKind] = createSignal<HackActivityType>();
     const [detailsId, setDetailsId] = createSignal<string>("");
+
     const [lnUrlData, setLnUrlData] = createSignal<LnUrlData>();
     const [fixedAmount, setFixedAmount] = createSignal(false);
     const [lnUrlExecuted, setLnUrlExecuted] = createSignal(false);
+
+    if (state.lnUrlData) {
+        initLnUrlWithdrawal(state.lnUrlData);
+    }
 
     const RECEIVE_FLAVORS = [
         {
@@ -182,6 +187,8 @@ export function Receive() {
         setError("");
         setFlavor(state.preferredInvoiceType);
         setLnUrlData(undefined);
+        setLnUrlExecuted(false);
+        setFixedAmount(false);
     }
 
     function openDetailsModal() {
@@ -336,17 +343,10 @@ export function Receive() {
         }
     }
 
-    // If we got here from an LNUrl withdrawal request
-    onMount(() => {
-        if (state.lnUrlData) {
-            initLnUrlWithdrawal(state.lnUrlData);
-            actions.setScanResult(undefined);
-            actions.setLnUrlData(undefined);
-        }
-    });
-
     function initLnUrlWithdrawal(lnUrlData: LnUrlData) {
         console.log("handleLnUrlWithdrawal", lnUrlData.lnurl, lnUrlData.params);
+        actions.setScanResult(undefined);
+        actions.setLnUrlData(undefined);
         setLnUrlData(lnUrlData);
         setError("");
         setFlavor("lightning");

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -12,7 +12,6 @@ import {
     createSignal,
     Match,
     onCleanup,
-    onMount,
     Show,
     Switch
 } from "solid-js";
@@ -534,9 +533,13 @@ export function Receive() {
                             amountSats={amount() ? amount().toString() : "0"}
                             kind={flavor()}
                         />
-                        <p class="text-center text-neutral-400">
-                            {i18n.t("receive.lnurl_withdrawal_in_progress")} ...
-                        </p>
+                        <Show when={lnUrlData()}>
+                            <p class="text-center text-neutral-400">
+                                {i18n.t("receive.lnurl_withdrawal_in_progress")}{" "}
+                                ...
+                            </p>
+                        </Show>
+
                         <p class="text-center text-neutral-400">
                             {i18n.t("receive.keep_mutiny_open")}
                         </p>

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -413,6 +413,13 @@ export function Receive() {
         return mSats / 1000n;
     }
 
+    function lnUrlAmountText(lnUrlData: LnUrlData) {
+        return i18n.t("receive.lnurl_amount_message", {
+            min: mSatsToSats(lnUrlData.params.min).toLocaleString(),
+            max: mSatsToSats(lnUrlData.params.max).toLocaleString()
+        });
+    }
+
     function selectFlavor(flavor: string) {
         setFlavor(flavor as ReceiveFlavor);
         if (rememberChoice()) {
@@ -473,6 +480,11 @@ export function Receive() {
                         }
                     >
                         <div class="flex-1" />
+                        <Show when={lnUrlData()}>
+                            <InfoBox accent="white">
+                                <p>{lnUrlAmountText(lnUrlData()!)}</p>
+                            </InfoBox>
+                        </Show>
                         <VStack>
                             <AmountEditable
                                 initialAmountSats={amount() || "0"}

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -385,10 +385,8 @@ export function Receive() {
                 amount()
             );
             if (!success) {
-                console.error("lnurl_withdraw failed result was false");
                 setError("lnurl_withdraw failed");
             } else {
-                console.log("lnurl_withdraw success");
                 setReceiveState("paid");
             }
         } catch (e) {
@@ -474,7 +472,6 @@ export function Receive() {
                             receiveState() === "edit"
                         }
                     >
-                        <h1>EDIT {amount().toString()}</h1>
                         <div class="flex-1" />
                         <VStack>
                             <AmountEditable
@@ -528,7 +525,7 @@ export function Receive() {
                             kind={flavor()}
                         />
                         <p class="text-center text-neutral-400">
-                            LNUrl withdrawal in progress...
+                            {i18n.t("receive.lnurl_withdrawal_in_progress")} ...
                         </p>
                         <p class="text-center text-neutral-400">
                             {i18n.t("receive.keep_mutiny_open")}
@@ -564,7 +561,6 @@ export function Receive() {
                         </Show>
                     </Match>
                     <Match when={receiveState() === "paid"}>
-                        <h1>PAID {amount().toString()}</h1>
                         <SuccessModal
                             open={!!paidState() || lnUrlExecuted()}
                             setOpen={(open: boolean) => {

--- a/src/routes/Scanner.tsx
+++ b/src/routes/Scanner.tsx
@@ -64,9 +64,13 @@ export function Scanner() {
                 },
                 (result) => {
                     if (result.lnurl && !result.is_lnurl_auth) {
+                        const lnurl = result.lnurl;
                         handleLnUrl(result.lnurl, (lnurlParams) => {
                             actions.setScanResult(result);
-                            actions.setLnUrlParams(lnurlParams);
+                            actions.setLnUrlData({
+                                lnurl: lnurl,
+                                params: lnurlParams
+                            });
                             if (lnurlParams.tag === "withdrawRequest") {
                                 navigate("/receive");
                             } else {

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -1,4 +1,4 @@
-import { LnUrlParams, MutinyInvoice, TagItem } from "@mutinywallet/mutiny-wasm";
+import { MutinyInvoice, TagItem } from "@mutinywallet/mutiny-wasm";
 import { useNavigate, useSearchParams } from "@solidjs/router";
 import {
     createEffect,

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -52,9 +52,6 @@ import { eify, vibrateSuccess } from "~/utils";
 
 export type SendSource = "lightning" | "onchain";
 
-// const TEST_DEST = "bitcoin:tb1pdh43en28jmhnsrhxkusja46aufdlae5qnfrhucw5jvefw9flce3sdxfcwe?amount=0.00001&label=heyo&lightning=lntbs10u1pjrwrdedq8dpjhjmcnp4qd60w268ve0jencwzhz048ruprkxefhj0va2uspgj4q42azdg89uupp5gngy2pqte5q5uvnwcxwl2t8fsdlla5s6xl8aar4xcsvxeus2w2pqsp5n5jp3pz3vpu92p3uswttxmw79a5lc566herwh3f2amwz2sp6f9tq9qyysgqcqpcxqrpwugv5m534ww5ukcf6sdw2m75f2ntjfh3gzeqay649256yvtecgnhjyugf74zakaf56sdh66ec9fqep2kvu6xv09gcwkv36rrkm38ylqsgpw3yfjl"
-// const TEST_DEST_ADDRESS = "tb1pdh43en28jmhnsrhxkusja46aufdlae5qnfrhucw5jvefw9flce3sdxfcwe"
-
 // TODO: better success / fail type
 type SentDetails = {
     amount?: bigint;

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -74,13 +74,13 @@ type MegaStore = [
         testflightPromptDismissed: boolean;
         should_zap_hodl: boolean;
         federations?: MutinyFederationIdentity[];
-        lnUrlParams?: LnUrlParams;
+        lnUrlData?: LnUrlData;
     },
     {
         setup(password?: string): Promise<void>;
         deleteMutinyWallet(): Promise<void>;
         setScanResult(scan_result: ParsedParams | undefined): void;
-        setLnUrlParams(lnUrlParams: LnUrlParams | undefined): void;
+        setLnUrlData(lnUrlData: LnUrlData | undefined): void;
         sync(): Promise<void>;
         setHasBackedUp(): void;
         listTags(): Promise<TagItem[]>;
@@ -104,6 +104,11 @@ type MegaStore = [
         refreshFederations(): Promise<void>;
     }
 ];
+
+export interface LnUrlData {
+    lnurl: string;
+    params: LnUrlParams;
+}
 
 export const Provider: ParentComponent = (props) => {
     const [searchParams] = useSearchParams();
@@ -145,7 +150,7 @@ export const Provider: ParentComponent = (props) => {
         testflightPromptDismissed:
             localStorage.getItem("testflightPromptDismissed") === "true",
         federations: undefined as MutinyFederationIdentity[] | undefined,
-        lnUrlParams: undefined as LnUrlParams | undefined
+        lnUrlData: undefined as LnUrlData | undefined
     });
 
     const actions = {
@@ -331,8 +336,8 @@ export const Provider: ParentComponent = (props) => {
                 return [];
             }
         },
-        setLnUrlParams(lnUrlParams: LnUrlParams | undefined) {
-            setState({ lnUrlParams });
+        setLnUrlData(lnUrlData: LnUrlData | undefined) {
+            setState({ lnUrlData });
         },
         async saveFiat(fiat: Currency) {
             localStorage.setItem("fiat_currency", JSON.stringify(fiat));

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -2,6 +2,7 @@
 
 // Inspired by https://github.com/solidjs/solid-realworld/blob/main/src/store/index.js
 import {
+    LnUrlParams,
     MutinyBalance,
     MutinyWallet,
     TagItem
@@ -73,11 +74,13 @@ type MegaStore = [
         testflightPromptDismissed: boolean;
         should_zap_hodl: boolean;
         federations?: MutinyFederationIdentity[];
+        lnUrlParams?: LnUrlParams;
     },
     {
         setup(password?: string): Promise<void>;
         deleteMutinyWallet(): Promise<void>;
         setScanResult(scan_result: ParsedParams | undefined): void;
+        setLnUrlParams(lnUrlParams: LnUrlParams | undefined): void;
         sync(): Promise<void>;
         setHasBackedUp(): void;
         listTags(): Promise<TagItem[]>;
@@ -141,7 +144,8 @@ export const Provider: ParentComponent = (props) => {
         should_zap_hodl: localStorage.getItem("should_zap_hodl") === "true",
         testflightPromptDismissed:
             localStorage.getItem("testflightPromptDismissed") === "true",
-        federations: undefined as MutinyFederationIdentity[] | undefined
+        federations: undefined as MutinyFederationIdentity[] | undefined,
+        lnUrlParams: undefined as LnUrlParams | undefined
     });
 
     const actions = {
@@ -326,6 +330,9 @@ export const Provider: ParentComponent = (props) => {
                 console.error(e);
                 return [];
             }
+        },
+        setLnUrlParams(lnUrlParams: LnUrlParams | undefined) {
+            setState({ lnUrlParams });
         },
         async saveFiat(fiat: Currency) {
             localStorage.setItem("fiat_currency", JSON.stringify(fiat));


### PR DESCRIPTION
Added very basic support for LNUrl withdrawal requests. I tried to just add the business logic and leave all graphical stuff untouched when possible (you probably don't want me to mess up your CI). 

The following UI related things will need some follow up:
- Add a paste field in the receive screen (LNUrl withdrawal can only be started from scan/paste screen as of now)
- Show a more telling loading screen while withdrawal is running. Right now it just shows a QR with checking (LNUrl can take a while)

Another thing I could not solve is to preset an fixed amount for the withdrawal (when min === max). Whenever I set the initial amount in the amount editor it is immediately reset to 0 from the editor (invoking the callback). I did not mess with that central component.