### PR TITLE
Payjoin alert only displayed when selecting onchain

### DIFF
--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -804,7 +804,7 @@ export function Send() {
                             setChosenMethod={setSourceFromMethod}
                         />
                     </Show>
-                    <Show when={payjoinEnabled()}>
+                    <Show when={payjoinEnabled() && source() === "onchain"}>
                         <InfoBox accent="green">
                             <p>{i18n.t("send.payjoin_send")}</p>
                         </InfoBox>


### PR DESCRIPTION
Saw a comment from the element chat where a bip21 had a lightning and pj component and the payjoin alert was displayed on both onchain and lightning. now payjoin alert only displays for onchain send.

[Kazam_screencast_00018.webm](https://github.com/MutinyWallet/mutiny-web/assets/108441023/33f3482a-5b14-48f0-b03c-7e15732fb4d9)
