### PR TITLE
Fedimint sweep

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.mutinywallet.mutinywallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 48
-        versionName "0.5.7"
+        versionCode 49
+        versionName "0.5.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.5.7;
+				MARKETING_VERSION = 1.5.8;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mutinywallet.mutiny;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -387,7 +387,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.5.7;
+				MARKETING_VERSION = 1.5.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mutinywallet.mutiny;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mutiny-wallet",
-    "version": "0.5.7",
+    "version": "0.5.8",
     "license": "MIT",
     "packageManager": "pnpm@8.6.6",
     "scripts": {
@@ -55,7 +55,7 @@
         "@kobalte/core": "^0.9.8",
         "@kobalte/tailwindcss": "^0.5.0",
         "@modular-forms/solid": "^0.18.1",
-        "@mutinywallet/mutiny-wasm": "0.5.7",
+        "@mutinywallet/mutiny-wasm": "0.5.8",
         "@mutinywallet/waila-wasm": "^0.2.6",
         "@solid-primitives/upload": "^0.0.111",
         "@solidjs/meta": "^0.29.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(solid-js@1.8.5)
       '@mutinywallet/mutiny-wasm':
-        specifier: 0.5.7
-        version: 0.5.7
+        specifier: 0.5.8
+        version: 0.5.8
       '@mutinywallet/waila-wasm':
         specifier: ^0.2.6
         version: 0.2.6
@@ -2570,8 +2570,8 @@ packages:
       solid-js: 1.8.5
     dev: false
 
-  /@mutinywallet/mutiny-wasm@0.5.7:
-    resolution: {integrity: sha512-swz7lFC86b8zWAc5gDz4I4O+66va2aOS9sHOkKhG0SEMp2vVti11Y4lpN0aJVuCy8Wx4FNZZLSxro00pYyf8kQ==}
+  /@mutinywallet/mutiny-wasm@0.5.8:
+    resolution: {integrity: sha512-Bwx3sMXuMiE876Kk1FI9uZoJMPkHc5RGFmUHsFeSMMGDxC2YLO5N5ilaIIig89ZbAYcBi7Y1N4Nq/2nZFcM+9A==}
     dev: false
 
   /@mutinywallet/waila-wasm@0.2.6:

--- a/src/components/BalanceBox.tsx
+++ b/src/components/BalanceBox.tsx
@@ -94,21 +94,38 @@ export function BalanceBox(props: { loading?: boolean }) {
                 <Show when={state.federations && state.federations.length}>
                     <Show when={!props.loading} fallback={<LoadingShimmer />}>
                         <hr class="my-2 border-m-grey-750" />
-                        <div class="flex flex-col gap-1">
-                            <div class="text-2xl">
-                                <AmountSats
-                                    amountSats={state.balance?.federation || 0}
-                                    icon="community"
-                                    denominationSize="lg"
-                                    isFederation
-                                />
+                        <div class="flex justify-between">
+                            <div class="flex flex-col gap-1">
+                                <div class="text-2xl">
+                                    <AmountSats
+                                        amountSats={
+                                            state.balance?.federation || 0
+                                        }
+                                        icon="community"
+                                        denominationSize="lg"
+                                        isFederation
+                                    />
+                                </div>
+                                <div class="text-lg text-white/70">
+                                    <AmountFiat
+                                        amountSats={
+                                            state.balance?.federation || 0n
+                                        }
+                                        denominationSize="sm"
+                                    />
+                                </div>
                             </div>
-                            <div class="text-lg text-white/70">
-                                <AmountFiat
-                                    amountSats={state.balance?.federation || 0n}
-                                    denominationSize="sm"
-                                />
-                            </div>
+                            <Show when={state.balance?.federation || 0n > 0n}>
+                                <div class="self-end justify-self-end">
+                                    <A href="/swaplightning" class={STYLE}>
+                                        <img
+                                            src={shuffle}
+                                            alt="swaplightning"
+                                            class="h-6 w-6"
+                                        />
+                                    </A>
+                                </div>
+                            </Show>
                         </div>
                     </Show>
                 </Show>

--- a/src/components/Failure.tsx
+++ b/src/components/Failure.tsx
@@ -1,0 +1,86 @@
+import { MutinyInvoice } from "@mutinywallet/mutiny-wasm";
+import { A, useNavigate, useSearchParams } from "@solidjs/router";
+import {
+    createEffect,
+    createMemo,
+    createResource,
+    createSignal,
+    JSX,
+    Match,
+    onMount,
+    Show,
+    Suspense,
+    Switch
+} from "solid-js";
+
+import bolt from "~/assets/icons/bolt.svg";
+import chain from "~/assets/icons/chain.svg";
+import close from "~/assets/icons/close.svg";
+import {
+    ActivityDetailsModal,
+    AmountEditable,
+    AmountFiat,
+    AmountSats,
+    BackPop,
+    Button,
+    DefaultMain,
+    Fee,
+    FeeDisplay,
+    HackActivityType,
+    InfoBox,
+    LabelCircle,
+    LoadingShimmer,
+    MegaCheck,
+    MegaClock,
+    MegaEx,
+    MethodChoice,
+    MutinyWalletGuard,
+    NavBar,
+    showToast,
+    SimpleInput,
+    SmallHeader,
+    StringShower,
+    SuccessModal,
+    UnstyledBackPop,
+    VStack
+} from "~/components";
+import { useI18n } from "~/i18n/context";
+import { ParsedParams } from "~/logic/waila";
+import { useMegaStore } from "~/state/megaStore";
+import { eify, vibrateSuccess } from "~/utils";
+
+export function Failure(props: { reason: string }) {
+    const i18n = useI18n();
+
+    return (
+        <Switch>
+            <Match when={props.reason === "Payment timed out."}>
+                <MegaClock />
+                <h1 class="mb-2 mt-4 w-full text-center text-2xl font-semibold md:text-3xl">
+                    {i18n.t("send.payment_pending")}
+                </h1>
+                <InfoBox accent="white">
+                    {i18n.t("send.payment_pending_description")}
+                </InfoBox>
+            </Match>
+            <Match
+                when={props.reason === "Channel reserve amount is too high."}
+            >
+                <MegaEx />
+                <h1 class="mb-2 mt-4 w-full text-center text-2xl font-semibold md:text-3xl">
+                    {i18n.t("send.error_channel_reserves")}
+                </h1>
+                <InfoBox accent="white">
+                    {i18n.t("send.error_channel_reserves_explained")}{" "}
+                    <A href="/settings/channels">{i18n.t("common.why")}</A>
+                </InfoBox>
+            </Match>
+            <Match when={true}>
+                <MegaEx />
+                <h1 class="mb-2 mt-4 w-full text-center text-2xl font-semibold md:text-3xl">
+                    {props.reason}
+                </h1>
+            </Match>
+        </Switch>
+    );
+}

--- a/src/components/Failure.tsx
+++ b/src/components/Failure.tsx
@@ -1,53 +1,8 @@
-import { MutinyInvoice } from "@mutinywallet/mutiny-wasm";
-import { A, useNavigate, useSearchParams } from "@solidjs/router";
-import {
-    createEffect,
-    createMemo,
-    createResource,
-    createSignal,
-    JSX,
-    Match,
-    onMount,
-    Show,
-    Suspense,
-    Switch
-} from "solid-js";
+import { A } from "@solidjs/router";
+import { Match, Switch } from "solid-js";
 
-import bolt from "~/assets/icons/bolt.svg";
-import chain from "~/assets/icons/chain.svg";
-import close from "~/assets/icons/close.svg";
-import {
-    ActivityDetailsModal,
-    AmountEditable,
-    AmountFiat,
-    AmountSats,
-    BackPop,
-    Button,
-    DefaultMain,
-    Fee,
-    FeeDisplay,
-    HackActivityType,
-    InfoBox,
-    LabelCircle,
-    LoadingShimmer,
-    MegaCheck,
-    MegaClock,
-    MegaEx,
-    MethodChoice,
-    MutinyWalletGuard,
-    NavBar,
-    showToast,
-    SimpleInput,
-    SmallHeader,
-    StringShower,
-    SuccessModal,
-    UnstyledBackPop,
-    VStack
-} from "~/components";
+import { InfoBox, MegaClock, MegaEx } from "~/components";
 import { useI18n } from "~/i18n/context";
-import { ParsedParams } from "~/logic/waila";
-import { useMegaStore } from "~/state/megaStore";
-import { eify, vibrateSuccess } from "~/utils";
 
 export function Failure(props: { reason: string }) {
     const i18n = useI18n();

--- a/src/components/ReceiveWarnings.tsx
+++ b/src/components/ReceiveWarnings.tsx
@@ -5,7 +5,10 @@ import { FeesModal } from "~/components/MoreInfoModal";
 import { useI18n } from "~/i18n/context";
 import { useMegaStore } from "~/state/megaStore";
 
-export function ReceiveWarnings(props: { amountSats: string | bigint }) {
+export function ReceiveWarnings(props: {
+    amountSats: string | bigint;
+    from_fedi_to_ln: boolean;
+}) {
     const i18n = useI18n();
     const [state, _actions] = useMegaStore();
 
@@ -26,7 +29,7 @@ export function ReceiveWarnings(props: { amountSats: string | bigint }) {
     });
 
     const warningText = () => {
-        if (state.federations?.length !== 0) {
+        if (state.federations?.length !== 0 && props.from_fedi_to_ln != true) {
             return undefined;
         }
         if ((state.balance?.lightning || 0n) === 0n) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -36,6 +36,7 @@ export * from "./Restart";
 export * from "./ResyncOnchain";
 export * from "./SeedWords";
 export * from "./SetupErrorDisplay";
+export * from "./Failure";
 export * from "./ShareCard";
 export * from "./Toaster";
 export * from "./NostrActivity";

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -603,7 +603,10 @@ export default {
     swap_lightning: {
         insufficient_funds: "You don't have enough funds to swap to lightning",
         header: "Swap to Lightning",
+        header_preview: "Preview Swap",
         completed: "Swap Completed",
+        too_small:
+            "Invalid amount entered. You need to swap at least 100k sats.",
         sats_added: "+{{amount}} sats have been added to your Lightning balance",
         sats_fee: "+{{amount}} sats fee",
         confirm_swap: "Confirm Swap",

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -600,6 +600,14 @@ export default {
         connecting: "Connecting...",
         confirm_swap: "Confirm Swap"
     },
+    swap_lightning: {
+        insufficient_funds: "You don't have enough funds to swap to lightning",
+        header: "Swap to Lightning",
+        completed: "Swap Completed",
+        sats_added: "+{{amount}} sats have been added to your Lightning balance",
+        sats_fee: "+{{amount}} sats fee",
+        confirm_swap: "Confirm Swap"
+    },
     reload: {
         mutiny_update: "Mutiny Update",
         new_version_description:

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -606,7 +606,8 @@ export default {
         completed: "Swap Completed",
         sats_added: "+{{amount}} sats have been added to your Lightning balance",
         sats_fee: "+{{amount}} sats fee",
-        confirm_swap: "Confirm Swap"
+        confirm_swap: "Confirm Swap",
+        preview_swap: "Preview Swap Fee"
     },
     reload: {
         mutiny_update: "Mutiny Update",

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -607,7 +607,8 @@ export default {
         completed: "Swap Completed",
         too_small:
             "Invalid amount entered. You need to swap at least 100k sats.",
-        sats_added: "+{{amount}} sats have been added to your Lightning balance",
+        sats_added:
+            "+{{amount}} sats have been added to your Lightning balance",
         sats_fee: "+{{amount}} sats fee",
         confirm_swap: "Confirm Swap",
         preview_swap: "Preview Swap Fee"

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -15,7 +15,8 @@ import {
     Scanner,
     Search,
     Send,
-    Swap
+    Swap,
+    SwapLightning
 } from "~/routes";
 import {
     Admin,
@@ -101,6 +102,7 @@ export function Router() {
                     <Route path="/scanner" component={Scanner} />
                     <Route path="/send" component={Send} />
                     <Route path="/swap" component={Swap} />
+                    <Route path="/swaplightning" component={SwapLightning} />
                     <Route path="/search" component={Search} />
                     <Route path="/settings">
                         <Route path="/" component={Settings} />

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -377,7 +377,10 @@ export function Receive() {
                                 setAmountSats={setAmount}
                                 onSubmit={getQr}
                             />
-                            <ReceiveWarnings amountSats={amount() || "0"} />
+                            <ReceiveWarnings
+                                amountSats={amount() || "0"}
+                                from_fedi_to_ln={false}
+                            />
                         </VStack>
                         <div class="flex-1" />
                         <VStack>

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -1,5 +1,5 @@
 import { MutinyInvoice, TagItem } from "@mutinywallet/mutiny-wasm";
-import { A, useNavigate, useSearchParams } from "@solidjs/router";
+import { useNavigate, useSearchParams } from "@solidjs/router";
 import {
     createEffect,
     createMemo,
@@ -33,8 +33,6 @@ import {
     LabelCircle,
     LoadingShimmer,
     MegaCheck,
-    MegaClock,
-    MegaEx,
     MethodChoice,
     MutinyWalletGuard,
     NavBar,
@@ -236,8 +234,8 @@ export function Send() {
                 ? sentDetails()?.txid
                 : undefined
             : sentDetails()
-            ? sentDetails()?.payment_hash
-            : undefined;
+              ? sentDetails()?.payment_hash
+              : undefined;
         const kind = sentDetails()?.txid ? "OnChain" : "Lightning";
 
         console.log("Opening details modal: ", paymentTxId, kind);

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -234,8 +234,8 @@ export function Send() {
                 ? sentDetails()?.txid
                 : undefined
             : sentDetails()
-              ? sentDetails()?.payment_hash
-              : undefined;
+            ? sentDetails()?.payment_hash
+            : undefined;
         const kind = sentDetails()?.txid ? "OnChain" : "Lightning";
 
         console.log("Opening details modal: ", paymentTxId, kind);

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -25,6 +25,7 @@ import {
     BackPop,
     Button,
     DefaultMain,
+    Failure,
     Fee,
     FeeDisplay,
     HackActivityType,
@@ -187,42 +188,6 @@ function DestinationItem(props: {
                 </div>
             </UnstyledBackPop>
         </div>
-    );
-}
-
-function Failure(props: { reason: string }) {
-    const i18n = useI18n();
-
-    return (
-        <Switch>
-            <Match when={props.reason === "Payment timed out."}>
-                <MegaClock />
-                <h1 class="mb-2 mt-4 w-full text-center text-2xl font-semibold md:text-3xl">
-                    {i18n.t("send.payment_pending")}
-                </h1>
-                <InfoBox accent="white">
-                    {i18n.t("send.payment_pending_description")}
-                </InfoBox>
-            </Match>
-            <Match
-                when={props.reason === "Channel reserve amount is too high."}
-            >
-                <MegaEx />
-                <h1 class="mb-2 mt-4 w-full text-center text-2xl font-semibold md:text-3xl">
-                    {i18n.t("send.error_channel_reserves")}
-                </h1>
-                <InfoBox accent="white">
-                    {i18n.t("send.error_channel_reserves_explained")}{" "}
-                    <A href="/settings/channels">{i18n.t("common.why")}</A>
-                </InfoBox>
-            </Match>
-            <Match when={true}>
-                <MegaEx />
-                <h1 class="mb-2 mt-4 w-full text-center text-2xl font-semibold md:text-3xl">
-                    {props.reason}
-                </h1>
-            </Match>
-        </Switch>
     );
 }
 

--- a/src/routes/SwapLightning.tsx
+++ b/src/routes/SwapLightning.tsx
@@ -1,0 +1,228 @@
+import { createForm, required } from "@modular-forms/solid";
+import { FedimintSweepResult } from "@mutinywallet/mutiny-wasm";
+import { useNavigate } from "@solidjs/router";
+import {
+    createMemo,
+    createResource,
+    createSignal,
+    For,
+    Match,
+    Show,
+    Switch
+} from "solid-js";
+
+import {
+    ActivityDetailsModal,
+    AmountEditable,
+    AmountFiat,
+    BackLink,
+    Button,
+    Card,
+    DefaultMain,
+    Failure,
+    Fee,
+    HackActivityType,
+    InfoBox,
+    LargeHeader,
+    MegaCheck,
+    MegaEx,
+    MutinyWalletGuard,
+    NavBar,
+    showToast,
+    SuccessModal,
+    TextField,
+    VStack
+} from "~/components";
+import { useI18n } from "~/i18n/context";
+import { Network } from "~/logic/mutinyWalletSetup";
+import { useMegaStore } from "~/state/megaStore";
+import { eify, vibrateSuccess } from "~/utils";
+
+type SweepResultDetails = {
+    result?: FedimintSweepResult;
+    failure_reason?: string;
+};
+
+export function SwapLightning() {
+    const [state, _actions] = useMegaStore();
+    const navigate = useNavigate();
+    const i18n = useI18n();
+
+    const [amountSats, setAmountSats] = createSignal(0n);
+
+    const [loading, setLoading] = createSignal(false);
+
+    // Details Modal
+    const [detailsOpen, setDetailsOpen] = createSignal(false);
+    const [detailsKind, setDetailsKind] = createSignal<HackActivityType>();
+    const [detailsId, setDetailsId] = createSignal("");
+
+    const [sweepResult, setSweepResult] = createSignal<SweepResultDetails>();
+
+    function resetState() {
+        setAmountSats(0n);
+        setLoading(false);
+        setSweepResult(undefined);
+    }
+
+    const handleSwap = async () => {
+        if (canSwap()) {
+            try {
+                setLoading(true);
+
+                if (isMax()) {
+                    const result =
+                        await state.mutiny_wallet?.sweep_federation_balance(
+                            undefined
+                        );
+
+                    setSweepResult({ result: result });
+                } else {
+                    const result =
+                        await state.mutiny_wallet?.sweep_federation_balance(
+                            amountSats()
+                        );
+
+                    setSweepResult({ result: result });
+                }
+
+                await vibrateSuccess();
+            } catch (e) {
+                const error = eify(e);
+                setSweepResult({ failure_reason: error.message });
+                console.error(e);
+            } finally {
+                setLoading(false);
+            }
+        }
+    };
+
+    const canSwap = () => {
+        const balance = state.balance?.federation || 0n;
+        const network = state.mutiny_wallet?.get_network() as Network;
+
+        return amountSats() <= balance;
+    };
+
+    const amountWarning = () => {
+        if (amountSats() === 0n || !!sweepResult() || loading()) {
+            return undefined;
+        }
+
+        if (amountSats() > (state.balance?.federation || 0n)) {
+            return i18n.t("swap.insufficient_funds");
+        }
+
+        return undefined;
+    };
+
+    function calculateMaxFederation() {
+        return state.balance?.federation ?? 0n;
+    }
+
+    const maxFederationBalance = createMemo(() => {
+        return calculateMaxFederation();
+    });
+
+    const isMax = createMemo(() => {
+        return amountSats() === calculateMaxFederation();
+    });
+
+    return (
+        <MutinyWalletGuard>
+            <DefaultMain>
+                <BackLink />
+                <LargeHeader>{i18n.t("swap.header")}</LargeHeader>
+                <SuccessModal
+                    confirmText={
+                        sweepResult()?.result
+                            ? i18n.t("common.nice")
+                            : i18n.t("common.home")
+                    }
+                    open={!!sweepResult()}
+                    setOpen={(open: boolean) => {
+                        if (!open) resetState();
+                    }}
+                    onConfirm={() => {
+                        resetState();
+                        navigate("/");
+                    }}
+                >
+                    <Switch>
+                        <Match when={sweepResult()?.failure_reason}>
+                            <Failure reason={sweepResult()?.failure_reason} />
+                        </Match>
+                        <Match when={sweepResult()?.result}>
+                            <Show when={detailsId() && detailsKind()}>
+                                <ActivityDetailsModal
+                                    open={detailsOpen()}
+                                    kind={detailsKind()}
+                                    id={detailsId()}
+                                    setOpen={setDetailsOpen}
+                                />
+                            </Show>
+                            <MegaCheck />
+                            <div class="flex flex-col justify-center">
+                                <h1 class="mb-2 mt-4 w-full justify-center text-center text-2xl font-semibold md:text-3xl">
+                                    {i18n.t("swap.completed")}
+                                </h1>
+                                <p class="text-center text-xl">
+                                    {i18n.t("swap.sats_added", {
+                                        amount: Number(
+                                            sweepResult()?.result?.amount
+                                        ).toLocaleString()
+                                    })}
+                                </p>
+                                <div class="text-center text-sm text-white/70">
+                                    <AmountFiat
+                                        amountSats={Number(
+                                            sweepResult()?.result?.amount
+                                        )}
+                                    />
+                                </div>
+                            </div>
+                            <hr class="w-16 bg-m-grey-400" />
+                            <Fee
+                                amountSats={Number(sweepResult()?.result?.fees)}
+                            />
+                        </Match>
+                    </Switch>
+                </SuccessModal>
+                <div class="flex flex-1 flex-col justify-between gap-2">
+                    <div class="flex-1" />
+                    <VStack biggap>
+                        <AmountEditable
+                            initialAmountSats={amountSats()}
+                            setAmountSats={setAmountSats}
+                            activeMethod={{
+                                method: "lightning",
+                                maxAmountSats: maxFederationBalance()
+                            }}
+                            methods={[
+                                {
+                                    method: "lightning",
+                                    maxAmountSats: maxFederationBalance()
+                                }
+                            ]}
+                        />
+                        <Show when={amountWarning() && amountSats() > 0n}>
+                            <InfoBox accent={"red"}>{amountWarning()}</InfoBox>
+                        </Show>
+                    </VStack>
+                    <div class="flex-1" />
+                    <VStack>
+                        <Button
+                            disabled={!canSwap()}
+                            intent="blue"
+                            onClick={handleSwap}
+                            loading={loading()}
+                        >
+                            {i18n.t("swap.confirm_swap")}
+                        </Button>
+                    </VStack>
+                </div>
+            </DefaultMain>
+            <NavBar activeTab="none" />
+        </MutinyWalletGuard>
+    );
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,4 +7,5 @@ export * from "./Receive";
 export * from "./Scanner";
 export * from "./Send";
 export * from "./Swap";
+export * from "./SwapLightning";
 export * from "./Search";


### PR DESCRIPTION
This does a few refactors on common components. 

Does the swap and warns the user when a channel fee may be required. However one critical part is to use `estimate_sweep_federation_fee` once the user has selected the amount so that they can see the fee before they continue. Handles a bit different than the lightning->channel open flow does today which is hard for me to replicate. 

Relies on https://github.com/MutinyWallet/mutiny-node/pull/995