### PR TITLE
Add eSats for federation amounts

### DIFF
--- a/e2e/fedimint.spec.ts
+++ b/e2e/fedimint.spec.ts
@@ -118,7 +118,7 @@ test("fedmint join, receive, send", async ({ page }) => {
     await expect(
         page
             .locator("div")
-            .filter({ hasText: /^100 SATS$/ })
+            .filter({ hasText: /^100 eSATS$/ })
             .nth(1)
     ).toBeVisible();
 

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -18,6 +18,7 @@ export function AmountSats(props: {
     amountSats: bigint | number | undefined;
     icon?: "lightning" | "community" | "chain" | "plus" | "minus";
     denominationSize?: "sm" | "lg" | "xl";
+    isFederation?: boolean;
 }) {
     const i18n = useI18n();
     return (
@@ -54,14 +55,18 @@ export function AmountSats(props: {
                             Number(props.amountSats) === 0
                         }
                     >
-                        {i18n.t("common.sats")}
+                        {props.isFederation
+                            ? i18n.t("common.e_sats")
+                            : i18n.t("common.sats")}
                     </Show>
                     <Show
                         when={
                             props.amountSats && Number(props.amountSats) === 1
                         }
                     >
-                        {i18n.t("common.sat")}
+                        {props.isFederation
+                            ? i18n.t("common.e_sat")
+                            : i18n.t("common.sat")}
                     </Show>
                 </span>
             </h1>

--- a/src/components/BalanceBox.tsx
+++ b/src/components/BalanceBox.tsx
@@ -100,6 +100,7 @@ export function BalanceBox(props: { loading?: boolean }) {
                                     amountSats={state.balance?.federation || 0}
                                     icon="community"
                                     denominationSize="lg"
+                                    isFederation
                                 />
                             </div>
                             <div class="text-lg text-white/70">

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -3,6 +3,8 @@ export default {
         title: "Mutiny Wallet",
         nice: "Nice",
         home: "Home",
+        e_sats: "eSATS",
+        e_sat: "eSat",
         sats: "SATS",
         sat: "SAT",
         fee: "Fee",

--- a/src/routes/settings/ManageFederations.tsx
+++ b/src/routes/settings/ManageFederations.tsx
@@ -185,6 +185,7 @@ function FederationListItem(props: {
                         <AmountSats
                             amountSats={props.balance}
                             denominationSize={"sm"}
+                            isFederation
                         />
                     </KeyValue>
                 </Show>


### PR DESCRIPTION
Closes #861 

![image](https://github.com/MutinyWallet/mutiny-web/assets/108441023/cd5d5c62-ea0a-42d0-be42-7e6666daef17)

![image](https://github.com/MutinyWallet/mutiny-web/assets/108441023/c6724fc5-7683-481a-91fd-e687ab39daff)

This is a new prop! curious if @futurepaul wants me to not add a prop for this and go another approach