### PR TITLE
Update translation keys

### DIFF
--- a/src/components/ChooseLanguage.tsx
+++ b/src/components/ChooseLanguage.tsx
@@ -23,7 +23,7 @@ export function ChooseLanguage() {
     const [_chooseLanguageForm, { Form, Field }] =
         createForm<ChooseLanguageForm>({
             initialValues: {
-                selectedLanguage: state.lang ?? ""
+                selectedLanguage: state.lang ?? i18n.language
             },
             validate: (values) => {
                 const errors: Record<string, string> = {};

--- a/src/components/ContactEditor.tsx
+++ b/src/components/ContactEditor.tsx
@@ -68,7 +68,7 @@ export function ContactEditor(props: {
                         previous: location.pathname
                     }}
                 >
-                    Import Nostr Contacts
+                    {i18n.t("contacts.link_to_nostr_sync")}
                 </A>
             </SimpleDialog>
         </>

--- a/src/components/ContactViewer.tsx
+++ b/src/components/ContactViewer.tsx
@@ -115,7 +115,7 @@ export function ContactViewer(props: {
                             intent="red"
                             onClick={() => setConfirmOpen(true)}
                         >
-                            Delete
+                            {i18n.t("contacts.delete")}
                         </Button>
                         <ConfirmDialog
                             open={confirmOpen()}
@@ -123,7 +123,7 @@ export function ContactViewer(props: {
                             onConfirm={handleDelete}
                             onCancel={() => setConfirmOpen(false)}
                         >
-                            Are you sure you want to delete this contact?
+                            {i18n.t("contacts.confirm_delete")}
                         </ConfirmDialog>
                     </Match>
                     <Match when={!isEditing()}>

--- a/src/components/MutinyPlusCta.tsx
+++ b/src/components/MutinyPlusCta.tsx
@@ -29,7 +29,8 @@ export function MutinyPlusCta() {
             >
                 <div class="flex justify-between">
                     <span>
-                        Mutiny<span class="text-m-red">+</span>
+                        {i18n.t("common.mutiny")}
+                        <span class="text-m-red">+</span>
                     </span>
                     <img src={forward} alt="go" />
                 </div>

--- a/src/i18n/en/translations.ts
+++ b/src/i18n/en/translations.ts
@@ -1,6 +1,7 @@
 export default {
     common: {
         title: "Mutiny Wallet",
+        mutiny: "Mutiny",
         nice: "Nice",
         home: "Home",
         e_sats: "eSATS",
@@ -33,6 +34,8 @@ export default {
         create_contact: "Create contact",
         edit_contact: "Edit contact",
         save_contact: "Save contact",
+        delete: "Delete",
+        confirm_delete: "Are you sure you want to delete this contact?",
         payment_history: "Payment history",
         no_payments: "No payments yet with",
         edit: "Edit",
@@ -47,7 +50,8 @@ export default {
         email_error: "That doesn't look like a lightning address",
         npub_error: "That doesn't look like a nostr npub",
         error_ln_address_missing: "New contacts need a lightning address",
-        npub: "Nostr Npub"
+        npub: "Nostr Npub",
+        link_to_nostr_sync: "Import Nostr Contacts"
     },
     receive: {
         receive_bitcoin: "Receive Bitcoin",
@@ -112,6 +116,13 @@ export default {
         what_for: "What's this for?"
     },
     send: {
+        search: {
+            placeholder: "Name, address, invoice",
+            paste: "Paste",
+            contacts: "Contacts",
+            global_search: "Global search",
+            no_results: "No results found for"
+        },
         sending: "Sending...",
         confirm_send: "Confirm Send",
         contact_placeholder: "Add the receiver for your records",
@@ -394,6 +405,8 @@ export default {
             }
         },
         encrypt: {
+            title: "Change Password",
+            caption: "Backup first to unlock encryption",
             header: "Encrypt your seed words",
             hot_wallet_warning:
                 'Mutiny is a "hot wallet" so it needs your seed word to operate, but you can optionally encrypt those words with a password.',
@@ -530,10 +543,12 @@ export default {
             save: "Save"
         },
         nostr_contacts: {
-            title: "Nostr Contacts",
+            title: "Sync Nostr Contacts",
             npub_label: "Nostr npub",
             npub_required: "Npub can't be blank",
-            sync: "Sync"
+            sync: "Sync",
+            resync: "Resync",
+            remove: "Remove"
         },
         manage_federations: {
             title: "Manage Federations",

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -261,7 +261,7 @@ function ActualSearch() {
                     type="text"
                     value={searchValue()}
                     onInput={(e) => setSearchValue(e.currentTarget.value)}
-                    placeholder="Name, address, invoice..."
+                    placeholder={i18n.t("send.search.placeholder")}
                     autofocus
                     ref={(el) => (searchInputRef = el)}
                 />
@@ -271,7 +271,7 @@ function ActualSearch() {
                         onClick={handlePaste}
                     >
                         <img src={paste} alt="Paste" class="h-4 w-4" />
-                        Paste
+                        {i18n.t("send.search.paste")}
                     </button>
                 </Show>
                 <Show when={!!searchValue()}>
@@ -285,14 +285,16 @@ function ActualSearch() {
             </div>
             <Show when={searchState() !== "notsendable"}>
                 <Button intent="green" onClick={handleContinue}>
-                    Continue
+                    {i18n.t("common.continue")}
                 </Button>
             </Show>
             <Show when={searchState() !== "sendable"}>
                 <div class="relative flex h-full max-h-[100svh] flex-col gap-3 overflow-y-scroll">
                     <Suspense>
                         <div class="sticky top-0 z-50 bg-m-grey-900/90 py-2 backdrop-blur-sm">
-                            <h2 class="text-xl font-semibold">Contacts</h2>
+                            <h2 class="text-xl font-semibold">
+                                {i18n.t("send.search.contacts")}
+                            </h2>
                         </div>
                         <Show
                             when={
@@ -314,7 +316,7 @@ function ActualSearch() {
                     <Suspense fallback={<LoadingShimmer />}>
                         <Show when={!!debouncedSearchValue()}>
                             <h2 class="py-2 text-xl font-semibold">
-                                Global Search
+                                {i18n.t("send.search.global_search")}
                             </h2>
                             <GlobalSearch
                                 searchValue={debouncedSearchValue()}
@@ -335,6 +337,7 @@ function GlobalSearch(props: {
     sendToContact: (contact: TagItem) => void;
     foundNpubs: (string | undefined)[];
 }) {
+    const i18n = useI18n();
     const hexpubs = createMemo(() => {
         const hexpubs: Set<string> = new Set();
         for (const npub of props.foundNpubs) {
@@ -403,7 +406,7 @@ function GlobalSearch(props: {
                 }
             >
                 <p class="text-neutral-500">
-                    No results found for "{props.searchValue}"
+                    {i18n.t("send.search.no_results") + " " + props.searchValue}
                 </p>
             </Match>
             <Match when={true}>

--- a/src/routes/settings/Root.tsx
+++ b/src/routes/settings/Root.tsx
@@ -107,10 +107,10 @@ export function Settings() {
                             },
                             {
                                 href: "/settings/encrypt",
-                                text: "Change Password",
+                                text: i18n.t("settings.encrypt.title"),
                                 disabled: !state.has_backed_up,
                                 caption: !state.has_backed_up
-                                    ? "Backup first to unlock encryption"
+                                    ? i18n.t("settings.encrypt.caption")
                                     : undefined
                             },
                             {
@@ -155,11 +155,13 @@ export function Settings() {
                             },
                             {
                                 href: "/settings/syncnostrcontacts",
-                                text: "Sync Nostr Contacts"
+                                text: i18n.t("settings.nostr_contacts.title")
                             },
                             {
                                 href: "/settings/federations",
-                                text: "Manage Federations"
+                                text: i18n.t(
+                                    "settings.manage_federations.title"
+                                )
                             }
                         ]}
                     />

--- a/src/routes/settings/SyncNostrContacts.tsx
+++ b/src/routes/settings/SyncNostrContacts.tsx
@@ -90,6 +90,7 @@ function SyncContactsForm() {
 }
 
 export function SyncNostrContacts() {
+    const i18n = useI18n();
     const [state, actions] = useMegaStore();
     const [loading, setLoading] = createSignal(false);
     const [error, setError] = createSignal<Error>();
@@ -114,7 +115,9 @@ export function SyncNostrContacts() {
             <SafeArea>
                 <DefaultMain>
                     <BackPop />
-                    <LargeHeader>Sync Nostr Contacts</LargeHeader>
+                    <LargeHeader>
+                        {i18n.t("settings.nostr_contacts.title")}
+                    </LargeHeader>
                     <Switch>
                         <Match when={state.npub}>
                             <VStack>
@@ -135,13 +138,17 @@ export function SyncNostrContacts() {
                                             onClick={resync}
                                             loading={loading()}
                                         >
-                                            Resync
+                                            {i18n.t(
+                                                "settings.nostr_contacts.resync"
+                                            )}
                                         </Button>
                                         <Button
                                             intent="red"
                                             onClick={clearNpub}
                                         >
-                                            Remove
+                                            {i18n.t(
+                                                "settings.nostr_contacts.remove"
+                                            )}
                                         </Button>
                                     </VStack>
                                 </FancyCard>

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -14,7 +14,7 @@ export const LANGUAGE_OPTIONS: Language[] = [
         shortName: "pt"
     },
     {
-        value: "Korean",
+        value: "한국어",
         shortName: "ko"
     }
 ];


### PR DESCRIPTION
Began working with someone to update the korean translation and figured I should go through and try to catch some stray text that was not using translation keys

also adds a small fallback enhancement for the language selector so that if there is no language state it checks if there is a i18n object instead of an empty string
```
selectedLanguage: state.lang ?? i18n.language
```