### PR TITLE
CI warnings for keys diff from fallback lang

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,7 +20,13 @@ module.exports = {
             rules: {
                 "@typescript-eslint/no-var-requires": "off" // Disable this specific rule for CJS files
             }
-        }
+        },
+        {
+            files: ['src/i18n/**/translations.ts'],
+            rules: {
+                "internal-rules/check-i18n-keys": "off" //Disabled so no warnings are presented everytime pre-commit is run
+            }
+        },      
     ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
@@ -32,7 +38,7 @@ module.exports = {
             jsx: true
         }
     },
-    plugins: ["@typescript-eslint", "solid", "import"],
+    plugins: ["@typescript-eslint", "solid", "import", "internal-rules"],
     rules: {
         "@typescript-eslint/no-unused-vars": [
             "warn",

--- a/README.md
+++ b/README.md
@@ -118,3 +118,57 @@ openssl base64 < <my-release-key.keystore> | tr -d '\n' | tee some_signing_key.j
     - `SIGNING_KEY` <- the data from `<my-release-key.keystore>`
 3. Change the `versionCode` and `versionName` on `app/build.gradle`
 4. Commit and push.
+
+## Translating
+
+### Testing language keys
+
+To check what keys are missing from your desired language:
+
+```
+just i18n $lang
+```
+
+### Adding new languages or keys
+
+1. In `src/i18n/` locate your desired language folder or create one if one does not exist
+    - When creating a new language dir ensure it follows the ISO 639 2-letter standard
+
+2. In this folder create a file called `translations.ts`, this is where the translation keys for your desired language will be located
+
+3. Populate your translation file with a translation object where all of the keys will be located
+
+If you want to add Japanese you will create a file `/src/i18n/jp/translations.ts` and populate it with keys like so:
+```
+export default {
+    Common: {
+        continue: "続ける",
+        ...
+    }
+}
+```
+(You should compare your translations against the English language as all other languages are not the master and are likely deprecated)
+
+4. Add your new translation file to the `/src/i18n/config.ts` so you can begin to see them in the app
+
+```
+import fa from "~/i18n/jp/translations.ts"
+
+export const resources: {
+    ...
+    jp: {
+        translations: jp
+    }
+}
+```
+
+5. Add your language to the `Language` object in `/src/utils/languages.ts`. This will allow you to select the language via the language selector in the UI. If your desired language is set as your primary language in your browser it will be selected automatically
+```
+export const LANGUAGE_OPTIONS: Language[] = [
+    {
+        value: "日本語",
+        shortName: "jp"
+    },
+```
+
+6. That's it! You should now be able to see your translation keys populating the app in your desired language. When youre ready go ahead and open a PR to have you language merged for others!

--- a/justfile
+++ b/justfile
@@ -6,6 +6,10 @@ dev:
 pre:
     pnpm run pre-commit
 
+i18n LANG:
+    #!/bin/bash
+    pnpm eslint-path "./src/i18n/{{LANG}}/translations.ts" --rule "{internal-rules/check-i18n-keys: warn}"
+
 local:
     pnpm install && pnpm link --global "@mutinywallet/mutiny-wasm"
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "build": "tsc && vite build",
         "check-types": "tsc --noemit",
         "eslint": "eslint src",
-        "pre-commit": "pnpm run eslint && pnpm run check-types && pnpm run format",
+        "eslint-path": "eslint",
+        "check-i18n-keys": "eslint src/i18n/**/translations.ts --rule \"{internal-rules/check-i18n-keys: warn}\"",
+        "pre-commit": "pnpm eslint && pnpm run check-types && pnpm run format",
         "format": "prettier --write \"{.,src/**,e2e/**}/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
         "check-format": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\""
     },
@@ -26,6 +28,7 @@
         "eslint": "^8.52.0",
         "eslint-import-resolver-typescript": "2.7.1",
         "eslint-plugin-import": "2.27.5",
+        "eslint-plugin-internal-rules": "file:tools/internal-rules",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-solid": "0.13.0",
         "postcss": "^8.4.31",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@6.9.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.52.0)
+      eslint-plugin-internal-rules:
+        specifier: file:tools/internal-rules
+        version: file:tools/internal-rules(eslint@8.52.0)
       eslint-plugin-prettier:
         specifier: 4.2.1
         version: 4.2.1(eslint@8.52.0)(prettier@3.0.3)
@@ -11565,6 +11568,11 @@ packages:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: true
 
+  /requireindex@1.2.0:
+    resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
+    engines: {node: '>=0.10.5'}
+    dev: true
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -13933,4 +13941,16 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  file:tools/internal-rules(eslint@8.52.0):
+    resolution: {directory: tools/internal-rules, type: directory}
+    id: file:tools/internal-rules
+    name: eslint-plugin-internal-rules
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
+    dependencies:
+      eslint: 8.52.0
+      requireindex: 1.2.0
     dev: true

--- a/tools/internal-rules/.eslintrc.js
+++ b/tools/internal-rules/.eslintrc.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+    root: true,
+    extends: [
+        "eslint:recommended",
+        "plugin:eslint-plugin/recommended",
+        "plugin:node/recommended"
+    ],
+    env: {
+        node: true
+    },
+    overrides: [
+        {
+            files: ["tests/**/*.js"],
+            env: { mocha: true }
+        }
+    ]
+};

--- a/tools/internal-rules/lib/index.js
+++ b/tools/internal-rules/lib/index.js
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview internal eslint rules
+ * @author
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const requireIndex = require("requireindex");
+
+//------------------------------------------------------------------------------
+// Plugin Definition
+//------------------------------------------------------------------------------
+
+// import all rules in lib/rules
+module.exports.rules = requireIndex(__dirname + "/rules");

--- a/tools/internal-rules/lib/rules/check-i18n-keys.js
+++ b/tools/internal-rules/lib/rules/check-i18n-keys.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("@babel/parser");
+
+module.exports = {
+    meta: {
+        name: "check-i18n-keys",
+        type: "suggestion",
+        docs: {
+            description:
+                "Ensure translation keys in other language files match the keys in the English translation file.",
+            category: "Best Practices",
+            recommended: true
+        },
+        fixable: null,
+        schema: []
+    },
+    create: function (context) {
+        function extractKeys(node, parentKey = "") {
+            const keys = [];
+            let properties = node.properties;
+
+            if (typeof node === "string") {
+                const fileContent = fs.readFileSync(node, "utf8");
+                const ast = parse(fileContent, {
+                    sourceType: "module",
+                    plugins: ["typescript", "jsx"]
+                });
+                properties =
+                    !!ast && ast.program.body[0].declaration.properties;
+            }
+
+            function traverseProperties(properties, parentKey) {
+                properties.forEach((property) => {
+                    if (
+                        (property.type === "ObjectProperty" ||
+                        property.type === "Property") &&
+                            property.key.type === "Identifier"
+                    ) {
+                        const currentKey = parentKey
+                            ? `${parentKey}.${property.key.name}`
+                            : property.key.name;
+                        keys.push(currentKey);
+                        if (property.value.type === "ObjectExpression") {
+                            traverseProperties(
+                                property.value.properties,
+                                currentKey
+                            );
+                        }
+                    }
+                });
+            }
+
+            traverseProperties(properties, parentKey);
+
+            return keys;
+        }
+
+        return {
+            Program(node) {
+                for (const statement of node.body) {
+                    const fallbackFilePath = path
+                        .relative(process.cwd(), context.getFilename())
+                        .replace(
+                            /\/i18n\/\w+\/translations\.ts$/,
+                            "/i18n/en/translations.ts"
+                        );
+
+                    const keys = extractKeys(statement.declaration);
+
+                    const enKeys = extractKeys(fallbackFilePath);
+
+                    // Report missing keys
+                    enKeys.forEach((enKey) => {
+                        if (!keys.includes(enKey)) {
+                            context.report({
+                                node: node,
+                                message: `missing key '${enKey}'`
+                            });
+                        }
+                    });
+
+                    // Report extra keys
+                    keys.forEach((key) => {
+                        if (!enKeys.includes(key)) {
+                            context.report({
+                                node: node,
+                                message: `extra key '${key}'`
+                            });
+                        }
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tools/internal-rules/package.json
+++ b/tools/internal-rules/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "eslint-plugin-internal-rules",
+    "version": "0.0.0",
+    "description": "internal eslint rules",
+    "keywords": [
+        "eslint",
+        "eslintplugin",
+        "eslint-plugin"
+    ],
+    "author": "",
+    "main": "./lib/index.js",
+    "exports": "./lib/index.js",
+    "scripts": {
+        "lint": "npm-run-all \"lint:*\"",
+        "lint:js": "eslint ."
+    },
+    "dependencies": {
+        "requireindex": "^1.2.0"
+    },
+    "devDependencies": {
+        "eslint": "^8.19.0",
+        "eslint-plugin-eslint-plugin": "^5.0.0",
+        "eslint-plugin-node": "^11.1.0"
+    },
+    "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+    },
+    "peerDependencies": {
+        "eslint": ">=7"
+    },
+    "license": "ISC"
+}

--- a/tools/internal-rules/pnpm-lock.yaml
+++ b/tools/internal-rules/pnpm-lock.yaml
@@ -1,0 +1,961 @@
+lockfileVersion: "6.0"
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+dependencies:
+    requireindex:
+        specifier: ^1.2.0
+        version: 1.2.0
+
+devDependencies:
+    eslint:
+        specifier: ^8.19.0
+        version: 8.19.0
+    eslint-plugin-eslint-plugin:
+        specifier: ^5.0.0
+        version: 5.0.0(eslint@8.19.0)
+    eslint-plugin-node:
+        specifier: ^11.1.0
+        version: 11.1.0(eslint@8.19.0)
+
+packages:
+    /@aashutoshrathi/word-wrap@1.2.6:
+        resolution:
+            {
+                integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /@eslint/eslintrc@1.4.1:
+        resolution:
+            {
+                integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        dependencies:
+            ajv: 6.12.6
+            debug: 4.3.4
+            espree: 9.6.1
+            globals: 13.24.0
+            ignore: 5.3.1
+            import-fresh: 3.3.0
+            js-yaml: 4.1.0
+            minimatch: 3.1.2
+            strip-json-comments: 3.1.1
+        transitivePeerDependencies:
+            - supports-color
+        dev: true
+
+    /@humanwhocodes/config-array@0.9.5:
+        resolution:
+            {
+                integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+            }
+        engines: { node: ">=10.10.0" }
+        dependencies:
+            "@humanwhocodes/object-schema": 1.2.1
+            debug: 4.3.4
+            minimatch: 3.1.2
+        transitivePeerDependencies:
+            - supports-color
+        dev: true
+
+    /@humanwhocodes/object-schema@1.2.1:
+        resolution:
+            {
+                integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+            }
+        dev: true
+
+    /acorn-jsx@5.3.2(acorn@8.11.3):
+        resolution:
+            {
+                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+            }
+        peerDependencies:
+            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+        dependencies:
+            acorn: 8.11.3
+        dev: true
+
+    /acorn@8.11.3:
+        resolution:
+            {
+                integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+            }
+        engines: { node: ">=0.4.0" }
+        hasBin: true
+        dev: true
+
+    /ajv@6.12.6:
+        resolution:
+            {
+                integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+            }
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-json-stable-stringify: 2.1.0
+            json-schema-traverse: 0.4.1
+            uri-js: 4.4.1
+        dev: true
+
+    /ansi-regex@5.0.1:
+        resolution:
+            {
+                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /ansi-styles@4.3.0:
+        resolution:
+            {
+                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            color-convert: 2.0.1
+        dev: true
+
+    /argparse@2.0.1:
+        resolution:
+            {
+                integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+            }
+        dev: true
+
+    /balanced-match@1.0.2:
+        resolution:
+            {
+                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+            }
+        dev: true
+
+    /brace-expansion@1.1.11:
+        resolution:
+            {
+                integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+            }
+        dependencies:
+            balanced-match: 1.0.2
+            concat-map: 0.0.1
+        dev: true
+
+    /callsites@3.1.0:
+        resolution:
+            {
+                integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+            }
+        engines: { node: ">=6" }
+        dev: true
+
+    /chalk@4.1.2:
+        resolution:
+            {
+                integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+            }
+        engines: { node: ">=10" }
+        dependencies:
+            ansi-styles: 4.3.0
+            supports-color: 7.2.0
+        dev: true
+
+    /color-convert@2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+            }
+        engines: { node: ">=7.0.0" }
+        dependencies:
+            color-name: 1.1.4
+        dev: true
+
+    /color-name@1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+            }
+        dev: true
+
+    /concat-map@0.0.1:
+        resolution:
+            {
+                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+            }
+        dev: true
+
+    /cross-spawn@7.0.3:
+        resolution:
+            {
+                integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            path-key: 3.1.1
+            shebang-command: 2.0.0
+            which: 2.0.2
+        dev: true
+
+    /debug@4.3.4:
+        resolution:
+            {
+                integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+            }
+        engines: { node: ">=6.0" }
+        peerDependencies:
+            supports-color: "*"
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+        dependencies:
+            ms: 2.1.2
+        dev: true
+
+    /deep-is@0.1.4:
+        resolution:
+            {
+                integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+            }
+        dev: true
+
+    /doctrine@3.0.0:
+        resolution:
+            {
+                integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+            }
+        engines: { node: ">=6.0.0" }
+        dependencies:
+            esutils: 2.0.3
+        dev: true
+
+    /escape-string-regexp@4.0.0:
+        resolution:
+            {
+                integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+            }
+        engines: { node: ">=10" }
+        dev: true
+
+    /eslint-plugin-es@3.0.1(eslint@8.19.0):
+        resolution:
+            {
+                integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+            }
+        engines: { node: ">=8.10.0" }
+        peerDependencies:
+            eslint: ">=4.19.1"
+        dependencies:
+            eslint: 8.19.0
+            eslint-utils: 2.1.0
+            regexpp: 3.2.0
+        dev: true
+
+    /eslint-plugin-eslint-plugin@5.0.0(eslint@8.19.0):
+        resolution:
+            {
+                integrity: sha512-4j1sOUmZEd6RsdRKjUbEwYLAcihOVlPLzX3jpLpp7d3lHM+nSlAXVAwCT8o2OfJ501LICr1v6OZo7b6tPzQkUQ==
+            }
+        engines: { node: ^14.17.0 || ^16.0.0 || >= 18.0.0 }
+        peerDependencies:
+            eslint: ">=7.0.0"
+        dependencies:
+            eslint: 8.19.0
+            eslint-utils: 3.0.0(eslint@8.19.0)
+            estraverse: 5.3.0
+        dev: true
+
+    /eslint-plugin-node@11.1.0(eslint@8.19.0):
+        resolution:
+            {
+                integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+            }
+        engines: { node: ">=8.10.0" }
+        peerDependencies:
+            eslint: ">=5.16.0"
+        dependencies:
+            eslint: 8.19.0
+            eslint-plugin-es: 3.0.1(eslint@8.19.0)
+            eslint-utils: 2.1.0
+            ignore: 5.3.1
+            minimatch: 3.1.2
+            resolve: 1.22.8
+            semver: 6.3.1
+        dev: true
+
+    /eslint-scope@7.2.2:
+        resolution:
+            {
+                integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        dependencies:
+            esrecurse: 4.3.0
+            estraverse: 5.3.0
+        dev: true
+
+    /eslint-utils@2.1.0:
+        resolution:
+            {
+                integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+            }
+        engines: { node: ">=6" }
+        dependencies:
+            eslint-visitor-keys: 1.3.0
+        dev: true
+
+    /eslint-utils@3.0.0(eslint@8.19.0):
+        resolution:
+            {
+                integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+            }
+        engines: { node: ^10.0.0 || ^12.0.0 || >= 14.0.0 }
+        peerDependencies:
+            eslint: ">=5"
+        dependencies:
+            eslint: 8.19.0
+            eslint-visitor-keys: 2.1.0
+        dev: true
+
+    /eslint-visitor-keys@1.3.0:
+        resolution:
+            {
+                integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+            }
+        engines: { node: ">=4" }
+        dev: true
+
+    /eslint-visitor-keys@2.1.0:
+        resolution:
+            {
+                integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+            }
+        engines: { node: ">=10" }
+        dev: true
+
+    /eslint-visitor-keys@3.4.3:
+        resolution:
+            {
+                integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        dev: true
+
+    /eslint@8.19.0:
+        resolution:
+            {
+                integrity: sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        hasBin: true
+        dependencies:
+            "@eslint/eslintrc": 1.4.1
+            "@humanwhocodes/config-array": 0.9.5
+            ajv: 6.12.6
+            chalk: 4.1.2
+            cross-spawn: 7.0.3
+            debug: 4.3.4
+            doctrine: 3.0.0
+            escape-string-regexp: 4.0.0
+            eslint-scope: 7.2.2
+            eslint-utils: 3.0.0(eslint@8.19.0)
+            eslint-visitor-keys: 3.4.3
+            espree: 9.6.1
+            esquery: 1.5.0
+            esutils: 2.0.3
+            fast-deep-equal: 3.1.3
+            file-entry-cache: 6.0.1
+            functional-red-black-tree: 1.0.1
+            glob-parent: 6.0.2
+            globals: 13.24.0
+            ignore: 5.3.1
+            import-fresh: 3.3.0
+            imurmurhash: 0.1.4
+            is-glob: 4.0.3
+            js-yaml: 4.1.0
+            json-stable-stringify-without-jsonify: 1.0.1
+            levn: 0.4.1
+            lodash.merge: 4.6.2
+            minimatch: 3.1.2
+            natural-compare: 1.4.0
+            optionator: 0.9.3
+            regexpp: 3.2.0
+            strip-ansi: 6.0.1
+            strip-json-comments: 3.1.1
+            text-table: 0.2.0
+            v8-compile-cache: 2.4.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: true
+
+    /espree@9.6.1:
+        resolution:
+            {
+                integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        dependencies:
+            acorn: 8.11.3
+            acorn-jsx: 5.3.2(acorn@8.11.3)
+            eslint-visitor-keys: 3.4.3
+        dev: true
+
+    /esquery@1.5.0:
+        resolution:
+            {
+                integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
+            }
+        engines: { node: ">=0.10" }
+        dependencies:
+            estraverse: 5.3.0
+        dev: true
+
+    /esrecurse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+            }
+        engines: { node: ">=4.0" }
+        dependencies:
+            estraverse: 5.3.0
+        dev: true
+
+    /estraverse@5.3.0:
+        resolution:
+            {
+                integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+            }
+        engines: { node: ">=4.0" }
+        dev: true
+
+    /esutils@2.0.3:
+        resolution:
+            {
+                integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /fast-deep-equal@3.1.3:
+        resolution:
+            {
+                integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+            }
+        dev: true
+
+    /fast-json-stable-stringify@2.1.0:
+        resolution:
+            {
+                integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+            }
+        dev: true
+
+    /fast-levenshtein@2.0.6:
+        resolution:
+            {
+                integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+            }
+        dev: true
+
+    /file-entry-cache@6.0.1:
+        resolution:
+            {
+                integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+            }
+        engines: { node: ^10.12.0 || >=12.0.0 }
+        dependencies:
+            flat-cache: 3.2.0
+        dev: true
+
+    /flat-cache@3.2.0:
+        resolution:
+            {
+                integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
+            }
+        engines: { node: ^10.12.0 || >=12.0.0 }
+        dependencies:
+            flatted: 3.3.1
+            keyv: 4.5.4
+            rimraf: 3.0.2
+        dev: true
+
+    /flatted@3.3.1:
+        resolution:
+            {
+                integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+            }
+        dev: true
+
+    /fs.realpath@1.0.0:
+        resolution:
+            {
+                integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+            }
+        dev: true
+
+    /function-bind@1.1.2:
+        resolution:
+            {
+                integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+            }
+        dev: true
+
+    /functional-red-black-tree@1.0.1:
+        resolution:
+            {
+                integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+            }
+        dev: true
+
+    /glob-parent@6.0.2:
+        resolution:
+            {
+                integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+            }
+        engines: { node: ">=10.13.0" }
+        dependencies:
+            is-glob: 4.0.3
+        dev: true
+
+    /glob@7.2.3:
+        resolution:
+            {
+                integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+            }
+        dependencies:
+            fs.realpath: 1.0.0
+            inflight: 1.0.6
+            inherits: 2.0.4
+            minimatch: 3.1.2
+            once: 1.4.0
+            path-is-absolute: 1.0.1
+        dev: true
+
+    /globals@13.24.0:
+        resolution:
+            {
+                integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            type-fest: 0.20.2
+        dev: true
+
+    /has-flag@4.0.0:
+        resolution:
+            {
+                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /hasown@2.0.1:
+        resolution:
+            {
+                integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==
+            }
+        engines: { node: ">= 0.4" }
+        dependencies:
+            function-bind: 1.1.2
+        dev: true
+
+    /ignore@5.3.1:
+        resolution:
+            {
+                integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
+            }
+        engines: { node: ">= 4" }
+        dev: true
+
+    /import-fresh@3.3.0:
+        resolution:
+            {
+                integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+            }
+        engines: { node: ">=6" }
+        dependencies:
+            parent-module: 1.0.1
+            resolve-from: 4.0.0
+        dev: true
+
+    /imurmurhash@0.1.4:
+        resolution:
+            {
+                integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+            }
+        engines: { node: ">=0.8.19" }
+        dev: true
+
+    /inflight@1.0.6:
+        resolution:
+            {
+                integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+            }
+        dependencies:
+            once: 1.4.0
+            wrappy: 1.0.2
+        dev: true
+
+    /inherits@2.0.4:
+        resolution:
+            {
+                integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+            }
+        dev: true
+
+    /is-core-module@2.13.1:
+        resolution:
+            {
+                integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
+            }
+        dependencies:
+            hasown: 2.0.1
+        dev: true
+
+    /is-extglob@2.1.1:
+        resolution:
+            {
+                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /is-glob@4.0.3:
+        resolution:
+            {
+                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+            }
+        engines: { node: ">=0.10.0" }
+        dependencies:
+            is-extglob: 2.1.1
+        dev: true
+
+    /isexe@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+            }
+        dev: true
+
+    /js-yaml@4.1.0:
+        resolution:
+            {
+                integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+            }
+        hasBin: true
+        dependencies:
+            argparse: 2.0.1
+        dev: true
+
+    /json-buffer@3.0.1:
+        resolution:
+            {
+                integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+            }
+        dev: true
+
+    /json-schema-traverse@0.4.1:
+        resolution:
+            {
+                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+            }
+        dev: true
+
+    /json-stable-stringify-without-jsonify@1.0.1:
+        resolution:
+            {
+                integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+            }
+        dev: true
+
+    /keyv@4.5.4:
+        resolution:
+            {
+                integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+            }
+        dependencies:
+            json-buffer: 3.0.1
+        dev: true
+
+    /levn@0.4.1:
+        resolution:
+            {
+                integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+            }
+        engines: { node: ">= 0.8.0" }
+        dependencies:
+            prelude-ls: 1.2.1
+            type-check: 0.4.0
+        dev: true
+
+    /lodash.merge@4.6.2:
+        resolution:
+            {
+                integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+            }
+        dev: true
+
+    /minimatch@3.1.2:
+        resolution:
+            {
+                integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+            }
+        dependencies:
+            brace-expansion: 1.1.11
+        dev: true
+
+    /ms@2.1.2:
+        resolution:
+            {
+                integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+            }
+        dev: true
+
+    /natural-compare@1.4.0:
+        resolution:
+            {
+                integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+            }
+        dev: true
+
+    /once@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+            }
+        dependencies:
+            wrappy: 1.0.2
+        dev: true
+
+    /optionator@0.9.3:
+        resolution:
+            {
+                integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==
+            }
+        engines: { node: ">= 0.8.0" }
+        dependencies:
+            "@aashutoshrathi/word-wrap": 1.2.6
+            deep-is: 0.1.4
+            fast-levenshtein: 2.0.6
+            levn: 0.4.1
+            prelude-ls: 1.2.1
+            type-check: 0.4.0
+        dev: true
+
+    /parent-module@1.0.1:
+        resolution:
+            {
+                integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+            }
+        engines: { node: ">=6" }
+        dependencies:
+            callsites: 3.1.0
+        dev: true
+
+    /path-is-absolute@1.0.1:
+        resolution:
+            {
+                integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /path-key@3.1.1:
+        resolution:
+            {
+                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /path-parse@1.0.7:
+        resolution:
+            {
+                integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+            }
+        dev: true
+
+    /prelude-ls@1.2.1:
+        resolution:
+            {
+                integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+            }
+        engines: { node: ">= 0.8.0" }
+        dev: true
+
+    /punycode@2.3.1:
+        resolution:
+            {
+                integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+            }
+        engines: { node: ">=6" }
+        dev: true
+
+    /regexpp@3.2.0:
+        resolution:
+            {
+                integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /requireindex@1.2.0:
+        resolution:
+            {
+                integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+            }
+        engines: { node: ">=0.10.5" }
+        dev: false
+
+    /resolve-from@4.0.0:
+        resolution:
+            {
+                integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+            }
+        engines: { node: ">=4" }
+        dev: true
+
+    /resolve@1.22.8:
+        resolution:
+            {
+                integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+            }
+        hasBin: true
+        dependencies:
+            is-core-module: 2.13.1
+            path-parse: 1.0.7
+            supports-preserve-symlinks-flag: 1.0.0
+        dev: true
+
+    /rimraf@3.0.2:
+        resolution:
+            {
+                integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+            }
+        hasBin: true
+        dependencies:
+            glob: 7.2.3
+        dev: true
+
+    /semver@6.3.1:
+        resolution:
+            {
+                integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+            }
+        hasBin: true
+        dev: true
+
+    /shebang-command@2.0.0:
+        resolution:
+            {
+                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            shebang-regex: 3.0.0
+        dev: true
+
+    /shebang-regex@3.0.0:
+        resolution:
+            {
+                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /strip-ansi@6.0.1:
+        resolution:
+            {
+                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            ansi-regex: 5.0.1
+        dev: true
+
+    /strip-json-comments@3.1.1:
+        resolution:
+            {
+                integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /supports-color@7.2.0:
+        resolution:
+            {
+                integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            has-flag: 4.0.0
+        dev: true
+
+    /supports-preserve-symlinks-flag@1.0.0:
+        resolution:
+            {
+                integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+            }
+        engines: { node: ">= 0.4" }
+        dev: true
+
+    /text-table@0.2.0:
+        resolution:
+            {
+                integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+            }
+        dev: true
+
+    /type-check@0.4.0:
+        resolution:
+            {
+                integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+            }
+        engines: { node: ">= 0.8.0" }
+        dependencies:
+            prelude-ls: 1.2.1
+        dev: true
+
+    /type-fest@0.20.2:
+        resolution:
+            {
+                integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+            }
+        engines: { node: ">=10" }
+        dev: true
+
+    /uri-js@4.4.1:
+        resolution:
+            {
+                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+            }
+        dependencies:
+            punycode: 2.3.1
+        dev: true
+
+    /v8-compile-cache@2.4.0:
+        resolution:
+            {
+                integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
+            }
+        dev: true
+
+    /which@2.0.2:
+        resolution:
+            {
+                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+            }
+        engines: { node: ">= 8" }
+        hasBin: true
+        dependencies:
+            isexe: 2.0.0
+        dev: true
+
+    /wrappy@1.0.2:
+        resolution:
+            {
+                integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+            }
+        dev: true


### PR DESCRIPTION
The way I went about this adds a whole new folder for internal eslint rules as I couldn't figure out how to add a single rule through a vite project. Additionally I could be far overcomplicating it with an eslint rule all together but I only found pre-made eslint plugins for json files not typescript files. At the end of the day the logic works but I would still like to try and simplify it.

ultimately this rule will be disabled exept when a translator wants to check their work they can switch it in the .eslintrc.cjs file from "off" => "warn" or whatever

while it doesn't use line numbers for the warning it specifies the key path for the dev to track down the missing or extra key
![image](https://github.com/MutinyWallet/mutiny-web/assets/108441023/fb384fa2-642d-4de2-b96a-d8bfbb53ef9c)
