### PR TITLE
Add `bitcoin` protocol handler for PWA

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -517,6 +517,12 @@ const manifest: Partial<ManifestOptions> = {
                 }
             ]
         }
+    ],
+    protocol_handlers: [
+        {
+            protocol: "bitcoin",
+            url: "/send?invoice=%s"
+        }
     ]
 };
 

--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -260,7 +260,7 @@ export function Send() {
             },
             (result) => {
                 actions.setScanResult(result);
-                navigate("/send", { state: { previous: "/search" } });
+                handleDestination(state.scan_result);
             }
         );
     }


### PR DESCRIPTION
Closes #547

In my testing I could only make the `bitcoin` handler work. This is likely due to the ["safelisted schemes"](https://html.spec.whatwg.org/multipage/system-state.html#safelisted-scheme).
The `send?invoice=%s` url was already being handled by the `parsePaste` function but the invoice data wasn't getting picked up, so I had to add the `handleDestination` call in there.