### PR TITLE
Fix NIP-05 handling for zap feed

### DIFF
--- a/src/utils/fetchZaps.ts
+++ b/src/utils/fetchZaps.ts
@@ -134,6 +134,11 @@ async function fetchFollows(npub: string): Promise<string[]> {
         throw err;
     }
 
+    // make sure we got a pubkey
+    if (!pubkey) {
+        throw new Error("Failed to get hexpub from npub");
+    }
+
     const response = await fetch(PRIMAL_API, {
         method: "POST",
         headers: {

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -50,7 +50,9 @@ export async function hexpubFromNpub(
     if (!npub) {
         return undefined;
     }
-    if (!npub.toLowerCase().startsWith("npub")) {
+    // if npub is not a valid npub, return undefined
+    // if it has an @, it's a NIP-05 address that we need to resolve
+    if (!npub.toLowerCase().startsWith("npub") && !npub.includes("@")) {
         return undefined;
     }
 


### PR DESCRIPTION
We support entering a nip-05 address in the sync nostr contacts form, however this would break the zap feed because it'd always return `undefined` when trying to get the hex pub. This fixes  it so we can actually resolve it into the hexpub as well as makes it so it'll return a better error when this happens.