### PR TITLE
Set inversion mode for scanner to 'both'

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -73,6 +73,9 @@ export function Reader(props: { onResult: (result: string) => void }) {
                 scanner = new QrScanner(container, handleResult, {
                     returnDetailedScanResult: true
                 });
+                // Set the inversion mode to scan both dark on light and light on dark
+                // This should make us more flexible in scanning QR codes
+                scanner.setInversionMode("both");
                 await scanner.start();
             }
         }


### PR DESCRIPTION
Was reading through the docs and seems like this would be beneficial 

https://github.com/nimiq/qr-scanner?tab=readme-ov-file#color-inverted-mode

potentially related to the user's issue in #935