### PR TITLE
Fix anonymous zaps

### DIFF
--- a/src/routes/Send.tsx
+++ b/src/routes/Send.tsx
@@ -515,7 +515,8 @@ export function Send() {
                     amountSats(),
                     zapNpub, // zap_npub
                     tags,
-                    comment // comment
+                    comment, // comment
+                    zapNpub ? "Anonymous" : undefined
                 );
                 sentDetails.payment_hash = payment?.payment_hash;
 


### PR DESCRIPTION
https://github.com/MutinyWallet/mutiny-node/pull/1040 broke anon zaps, now requires you to put the type of zap you're doing.

We should add public and private zaps eventually, but this fixes the functionality for now