### PR TITLE
Change password renamed to security

### DIFF
--- a/e2e/encrypt.spec.ts
+++ b/e2e/encrypt.spec.ts
@@ -39,7 +39,7 @@ test("test local encrypt", async ({ page }) => {
 
     // Go back to settings / change password
     await visitSettings(page);
-    await page.click("text=Change Password");
+    await page.click("text=Security");
 
     // The header should now say "Encrypt your seed words"
     await expect(page.locator("h1")).toContainText(["Encrypt your seed words"]);

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -405,7 +405,7 @@
       }
     },
     "encrypt": {
-      "title": "Change Password",
+      "title": "Security",
       "caption": "Backup first to unlock encryption",
       "header": "Encrypt your seed words",
       "hot_wallet_warning": "Mutiny is a \"hot wallet\" so it needs your seed word to operate, but you can optionally encrypt those words with a password.",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -362,7 +362,7 @@
       }
     },
     "encrypt": {
-      "title": "Cambiar Contraseña",
+      "title": "Seguridad",
       "caption": "Haga un respaldo primero para desbloquear el cifrado",
       "header": "Cifre sus palabras semilla",
       "hot_wallet_warning": "Mutiny es una \"billetera caliente\" por lo que necesita sus palabras semilla para operar, pero usted puede opcionalmente cifrar esas palabras con una contraseña.",

--- a/public/i18n/ko.json
+++ b/public/i18n/ko.json
@@ -284,7 +284,7 @@
       }
     },
     "encrypt": {
-      "header": "시드 단어 암호화",
+      "header": "보안",
       "hot_wallet_warning": "Mutiny는 &rdquo;핫 월렛&rdquo;이므로 시드 단어를 사용하여 작동하지만 선택적으로 비밀번호로 암호화할 수 있습니다.",
       "password_tip": "이렇게 하면 다른 사람이 브라우저에 접근하더라도 자금에 접근할 수 없습니다.",
       "optional": "(선택 사항)",


### PR DESCRIPTION
Since it doesn't prompt for setting a password, the 'change password' name is a bit incorrect. Just renamed to security in general. 