### PR TITLE
don't allow rando text selection

### DIFF
--- a/src/root.css
+++ b/src/root.css
@@ -4,6 +4,7 @@
 
 * {
     touch-action: manipulation;
+    user-select: none;
 }
 
 html {


### PR DESCRIPTION
fixes stuff like this:

![signal-2024-04-02-140953_002](https://github.com/MutinyWallet/mutiny-web/assets/543668/0f02fb30-e6b0-46d9-95cb-8845bd860d77)

text selection should still work in text boxes, but can't think of anything else that requires it