### PR TITLE
Don't set NIP-05 after lightning address

### DIFF
--- a/src/routes/settings/LightningAddress.tsx
+++ b/src/routes/settings/LightningAddress.tsx
@@ -73,15 +73,12 @@ function HermesForm(props: { onSubmit: (name: string) => void }) {
 
             const formattedName = `${name}@${hermesDomain}`;
 
-            const existingProfile = state.mutiny_wallet?.get_nostr_profile();
-
             const _ = await state.mutiny_wallet?.edit_nostr_profile(
                 undefined,
                 undefined,
                 // lnurl
                 formattedName,
-                // nip05 if they don't have one
-                existingProfile?.nip05 ? undefined : formattedName
+                undefined
             );
             reset(nameForm);
             props.onSubmit(name);


### PR DESCRIPTION
this is my bad, we don't use the actual user's key for the nip05 we setup so we shouldn't set this. Maybe we'll fix in the backend and we can revert this