### PR TITLE
timeout if load fails

### DIFF
--- a/src/logic/mutinyWalletSetup.ts
+++ b/src/logic/mutinyWalletSetup.ts
@@ -233,7 +233,7 @@ export async function setupMutinyWallet(
     password?: string,
     safeMode?: boolean,
     shouldZapHodl?: boolean
-): Promise<MutinyWallet> {
+): Promise<MutinyWallet | undefined> {
     console.log("Starting setup...");
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Storage_API
@@ -350,5 +350,9 @@ export async function setupMutinyWallet(
 
     sessionStorage.setItem("MUTINY_WALLET_INITIALIZED", Date.now().toString());
 
-    return mutinyWallet;
+    if (mutinyWallet) {
+        return mutinyWallet;
+    } else {
+        return undefined;
+    }
 }


### PR DESCRIPTION
if mutiny-wasm panics during setup, that function never returns and no error is thrown, which stalls setup indefinitely. this sets up a timer so if it takes more than 60s mutiny-web will give up and show an error state

interestingly, functions seem to get polluted by a panicked wasm thing so throwing errors stops working as it should (they become uncaught)

this might help with #1070 