### PR TITLE
bump the timeout and make sure we're not done loading

### DIFF
--- a/e2e/roundtrip.spec.ts
+++ b/e2e/roundtrip.spec.ts
@@ -124,6 +124,9 @@ test("rountrip receive and send", async ({ page }) => {
 
     await page.click("text=Online Channels");
 
+    // Give it just a second to settle down
+    await page.waitForTimeout(2000);
+
     await page.click("text=Close");
 
     await page.click("text=Confirm");

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -204,20 +204,23 @@ export const Provider: ParentComponent = (props) => {
                     await setSettings(settings);
                 }
 
-                // 60 seconds to load or we bail
+                // 90 seconds to load or we bail
                 const start = Date.now();
-                const MAX_LOAD_TIME = 60000;
+                const MAX_LOAD_TIME = 90000;
                 const interval = setInterval(() => {
                     console.log("Running setup", Date.now() - start);
                     if (Date.now() - start > MAX_LOAD_TIME) {
                         clearInterval(interval);
-                        // Have to set state error here because throwing doesn't work if WASM panics
-                        setState({
-                            setup_error: new Error(
-                                "Load timed out, please try again"
-                            )
-                        });
-                        return;
+                        // Only want to do this if we're really not done loading
+                        if (state.load_stage !== "done") {
+                            // Have to set state error here because throwing doesn't work if WASM panics
+                            setState({
+                                setup_error: new Error(
+                                    "Load timed out, please try again"
+                                )
+                            });
+                            return;
+                        }
                     }
                 }, 1000);
 


### PR DESCRIPTION
Someone reported the wallet was loading and then hitting the timeout thing after. I don't know how that would happen, it would seem somehow the timeout interval isn't being cleared. This makes it so even if the timeout is triggered, it won't do anything if the loading is done.