### PR TITLE
Force close channel if offline

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -343,7 +343,8 @@
       "close_channel": "Close",
       "online_channels": "Online Channels",
       "offline_channels": "Offline Channels",
-      "close_channel_confirm": "Closing this channel will move the balance on-chain and incur an on-chain fee."
+      "close_channel_confirm": "Closing this channel will move the balance on-chain and incur an on-chain fee.",
+      "force_close_channel_confirm": "This channel is offline. Force closing this channel will move the balance on-chain, incur an on-chain fee, and may take a few days to settle."
     },
     "connections": {
       "title": "Wallet Connections",

--- a/src/routes/settings/Channels.tsx
+++ b/src/routes/settings/Channels.tsx
@@ -98,7 +98,7 @@ function splitChannelNumbers(channel: MutinyChannel): {
     };
 }
 
-function SingleChannelItem(props: { channel: MutinyChannel }) {
+function SingleChannelItem(props: { channel: MutinyChannel; online: boolean }) {
     const i18n = useI18n();
     const [state, _actions] = useMegaStore();
     const network = state.mutiny_wallet?.get_network() as Network;
@@ -114,9 +114,10 @@ function SingleChannelItem(props: { channel: MutinyChannel }) {
         try {
             if (!props.channel.outpoint) return;
             setConfirmLoading(true);
+            const forceClose = !props.online;
             await state.mutiny_wallet?.close_channel(
                 props.channel.outpoint,
-                false,
+                forceClose,
                 false
             );
         } catch (e) {
@@ -161,7 +162,16 @@ function SingleChannelItem(props: { channel: MutinyChannel }) {
                     onConfirm={closeChannel}
                     onCancel={() => setConfirmOpen(false)}
                 >
-                    {i18n.t("settings.channels.close_channel_confirm")}
+                    <Switch>
+                        <Match when={!props.online}>
+                            {i18n.t(
+                                "settings.channels.force_close_channel_confirm"
+                            )}
+                        </Match>
+                        <Match when={true}>
+                            {i18n.t("settings.channels.close_channel_confirm")}
+                        </Match>
+                    </Switch>
                 </ConfirmDialog>
             </VStack>
         </Card>
@@ -259,6 +269,7 @@ function LiquidityMonitor() {
                                         {(channel) => (
                                             <SingleChannelItem
                                                 channel={channel}
+                                                online={true}
                                             />
                                         )}
                                     </For>
@@ -279,6 +290,7 @@ function LiquidityMonitor() {
                                         {(channel) => (
                                             <SingleChannelItem
                                                 channel={channel}
+                                                online={false}
                                             />
                                         )}
                                     </For>


### PR DESCRIPTION
Had to help a user today where they were trying to close a channel while their channel was offline which always failed because it would try to cooperative close. This will make it force close if the channel is offline.