### PR TITLE
Show disabled NWCs again

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -378,7 +378,10 @@
       "confirm_delete": "Are you sure you want to delete this connection?",
       "budget": "Budget",
       "resets_every": "Resets every",
-      "resubscribe_date": "Resubscribe on"
+      "resubscribe_date": "Resubscribe on",
+      "disable_connection": "Disable",
+      "disabled": "This subscription is disabled. Currently you can't re-enable subscriptions, but we're working to fix that. Check back soon!",
+      "disable_connection_confirm": "Are you sure you want to disable your subscription? Currently subscriptions can't be re-enabled, we're working to fix that."
     },
     "emergency_kit": {
       "title": "Emergency Kit",

--- a/src/routes/settings/Connections.tsx
+++ b/src/routes/settings/Connections.tsx
@@ -223,8 +223,10 @@ function Nwc() {
     const [profileToOpen, setProfileToOpen] = createSignal<number>();
 
     function editProfile(profile: NwcProfile) {
-        setProfileToOpen(profile.index);
-        setDialogOpen(true);
+        if (profile && typeof profile.index === "number") {
+            setProfileToOpen(profile.index);
+            setDialogOpen(true);
+        }
     }
 
     function createProfile() {
@@ -294,7 +296,7 @@ function Nwc() {
                 open={dialogOpen()}
                 setOpen={handleToggleOpen}
                 title={
-                    profileToOpen()
+                    typeof profileToOpen() === "number"
                         ? i18n.t("settings.connections.edit_connection")
                         : i18n.t("settings.connections.add_connection")
                 }

--- a/src/routes/settings/Connections.tsx
+++ b/src/routes/settings/Connections.tsx
@@ -150,9 +150,18 @@ function NwcDetails(props: {
                 </Show>
             </Show>
 
-            <Button layout="small" intent="green" onClick={props.onEdit}>
-                {i18n.t("settings.connections.edit_budget")}
-            </Button>
+            <Show
+                when={props.profile.enabled}
+                fallback={
+                    <InfoBox accent="red">
+                        {i18n.t("settings.connections.disabled")}
+                    </InfoBox>
+                }
+            >
+                <Button layout="small" intent="green" onClick={props.onEdit}>
+                    {i18n.t("settings.connections.edit_budget")}
+                </Button>
+            </Show>
 
             <Show
                 when={
@@ -170,16 +179,22 @@ function NwcDetails(props: {
                 </Button>
             </Show>
 
-            <Button layout="small" onClick={confirmDelete}>
-                {i18n.t("settings.connections.delete_connection")}
-            </Button>
+            <Show when={props.profile.enabled}>
+                <Button layout="small" onClick={confirmDelete}>
+                    {props.profile.tag === "Subscription"
+                        ? i18n.t("settings.connections.disable_connection")
+                        : i18n.t("settings.connections.delete_connection")}
+                </Button>
+            </Show>
             <ConfirmDialog
                 loading={false}
                 open={confirmOpen()}
                 onConfirm={deleteProfile}
                 onCancel={() => setConfirmOpen(false)}
             >
-                {i18n.t("settings.connections.confirm_delete")}
+                {props.profile.tag === "Subscription"
+                    ? i18n.t("settings.connections.disable_connection_confirm")
+                    : i18n.t("settings.connections.confirm_delete")}
             </ConfirmDialog>
         </VStack>
     );

--- a/src/routes/settings/Connections.tsx
+++ b/src/routes/settings/Connections.tsx
@@ -277,7 +277,7 @@ function Nwc() {
                         {(profile) => (
                             <Collapser
                                 title={profile.name}
-                                activityLight={"on"}
+                                activityLight={profile.enabled ? "on" : "off"}
                                 defaultOpen={profile.index === newConnection()}
                             >
                                 <NwcDetails


### PR DESCRIPTION
Needs https://github.com/MutinyWallet/mutiny-node/pull/1173

There's nothing yet to enable a disabled profile, but there's a few things broken with this NWC connection page with it comes to our mutiny+ connection. This at least makes sure that profiles are "disabled/deleted" properly and it reflects it in the UI.