### PR TITLE
add limit for get_contacts_sorted

### DIFF
--- a/src/components/PendingNwc.tsx
+++ b/src/components/PendingNwc.tsx
@@ -1,4 +1,3 @@
-import { TagItem } from "@mutinywallet/mutiny-wasm";
 import { useNavigate } from "@solidjs/router";
 import { Check, PlugZap, X } from "lucide-solid";
 import {
@@ -42,7 +41,7 @@ export function PendingNwc() {
         setHasPreConfiguredNWC(!!profiles && profiles.length > 0);
         if (!profiles) return [];
 
-        const contacts: TagItem[] | undefined = await sw.get_contacts_sorted();
+        const contacts = await sw.get_contacts_sorted();
         if (!contacts) return [];
 
         const pending = await sw.get_pending_nwc_invoices();

--- a/src/components/SocialActionRow.tsx
+++ b/src/components/SocialActionRow.tsx
@@ -15,7 +15,7 @@ export function SocialActionRow(props: {
 
     const getContacts = cache(async () => {
         try {
-            const contacts: TagItem[] = (await sw.get_contacts_sorted()) || [];
+            const contacts = await sw.get_contacts_sorted(40);
             const myNpub = (await sw.get_npub()) || "";
 
             // contact must have a npub, ln_address, or lnurl

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -88,8 +88,7 @@ function ActualSearch(props: { initialValue?: string }) {
 
     const getContacts = cache(async () => {
         try {
-            const contacts = await sw.get_contacts_sorted();
-            return contacts || ([] as TagItem[]);
+            return await sw.get_contacts_sorted(40);
         } catch (e) {
             console.error(e);
             return [] as TagItem[];

--- a/src/workers/walletWorker.ts
+++ b/src/workers/walletWorker.ts
@@ -384,9 +384,14 @@ export async function get_invoice(
  * Gets all contacts sorted by last used
  * @returns {Promise<any>}
  */
-export async function get_contacts_sorted(): Promise<TagItem[] | undefined> {
+export async function get_contacts_sorted(limit?: number): Promise<TagItem[]> {
     const contacts = await wallet!.get_contacts_sorted();
-    return contacts;
+    if (!contacts) return [];
+    if (contacts.length && limit) {
+        return contacts.slice(0, limit);
+    } else {
+        return contacts;
+    }
 }
 
 export async function edit_contact(
@@ -966,7 +971,6 @@ export async function approve_nostr_wallet_auth(
  */
 export async function get_nwc_profile(index: number): Promise<NwcProfile> {
     const profile = await wallet!.get_nwc_profile(index);
-    console.log("get_nwc_profile", profile);
     return {
         ...profile.value
     } as NwcProfile;


### PR DESCRIPTION
in search of performance problems, this saves my wallet from timing out on a bunch of random profiles with broken image urls, plus all the work of fetching / serializing the profiles that do work

40 feels like a nice default