### PR TITLE
Immediately timestamp double init defense

### DIFF
--- a/src/logic/mutinyWalletSetup.ts
+++ b/src/logic/mutinyWalletSetup.ts
@@ -180,13 +180,19 @@ export async function doubleInitDefense() {
     // Ultimate defense against getting multiple instances of the wallet running.
     // If we detect that the wallet has already been initialized in this session, we'll reload the page.
     // A successful stop of the wallet in onCleanup will clear this flag
-    if (sessionStorage.getItem("MUTINY_WALLET_INITIALIZED")) {
+    const init = sessionStorage.getItem("MUTINY_WALLET_INITIALIZED");
+    if (init) {
+        const diff = Date.now() - Number(init);
         console.error(
-            `Mutiny Wallet already initialized at ${sessionStorage.getItem(
-                "MUTINY_WALLET_INITIALIZED"
-            )}. Reloading page.`
+            `Mutiny Wallet already initialized at ${init}, ${diff}ms ago. Reloading page.`
         );
         sessionStorage.removeItem("MUTINY_WALLET_INITIALIZED");
         window.location.reload();
+    } else {
+        // Timestamp our initialization for double init defense
+        sessionStorage.setItem(
+            "MUTINY_WALLET_INITIALIZED",
+            Date.now().toString()
+        );
     }
 }

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -263,12 +263,6 @@ export const makeMegaStoreContext = () => {
                     expiration_warning
                 });
 
-                // Timestamp our initialization for double init defense
-                sessionStorage.setItem(
-                    "MUTINY_WALLET_INITIALIZED",
-                    Date.now().toString()
-                );
-
                 console.log("Wallet initialized");
 
                 await actions.postSetup();


### PR DESCRIPTION
Before we would not set the session storage double init defense until after the wallet was initialized. This changes it to when we verify it isn't set, this way we immediately "claim the lock" instead of waiting until the wallet is loaded. Also cleaned up the error message to be more informative.

Not sure if this will actually fix anything but found this while trying to find init error