### PR TITLE
make ios webview inspectable by safari in release

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -8,6 +8,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        if #available(iOS 16.4, *) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+                if let vc = self.window?.rootViewController as? CAPBridgeViewController {
+                    vc.bridgedWebView?.isInspectable = true;
+                }
+            }
+        }
+        
         return true
     }
 


### PR DESCRIPTION
got this from https://stackoverflow.com/a/77107393

this seems to be working but I can only test with a version I built locally so would need to get it up in testflight to know for sure this works for all builds