### PR TITLE
Remove LSP url from servers

### DIFF
--- a/src/components/KitchenSink.tsx
+++ b/src/components/KitchenSink.tsx
@@ -466,11 +466,11 @@ function LSPS(props: { initialSettings: MutinyWalletSettingStrings }) {
         console.log("values", values);
         try {
             await sw.change_lsp(
-                values.lsp ? values.lsp : undefined,
+                values.lsp ? values.lsp.trim() : undefined,
                 values.lsps_connection_string
-                    ? values.lsps_connection_string
+                    ? values.lsps_connection_string.trim()
                     : undefined,
-                values.lsps_token ? values.lsps_token : undefined
+                values.lsps_token ? values.lsps_token.trim() : undefined
             );
             await setSettings(values);
             window.location.reload();

--- a/src/routes/settings/Servers.tsx
+++ b/src/routes/settings/Servers.tsx
@@ -132,26 +132,6 @@ function SettingsStringsEditor(props: {
                     )}
                 </Field>
                 <Field
-                    name="lsp"
-                    validate={[
-                        url(i18n.t("settings.servers.error_lsp")),
-                        custom(
-                            validateNotTorUrl,
-                            i18n.t("settings.servers.error_tor")
-                        )
-                    ]}
-                >
-                    {(field, props) => (
-                        <TextField
-                            {...props}
-                            value={field.value}
-                            error={field.error}
-                            label={i18n.t("settings.servers.lsp_label")}
-                            caption={i18n.t("settings.servers.lsp_caption")}
-                        />
-                    )}
-                </Field>
-                <Field
                     name="storage"
                     validate={[
                         url(i18n.t("settings.servers.error_lsp")),


### PR DESCRIPTION
First commit removes the LSP url from the servers page, this shouldn't be changed from here but from the admin page so we make sure we call the `change_lsp` function.

Second commit calls trim on all the lsp urls to help prevent issues